### PR TITLE
Add api.massive.com to global fetch allowlist

### DIFF
--- a/docs/capabilities/server/http-fetch-policy.md
+++ b/docs/capabilities/server/http-fetch-policy.md
@@ -71,6 +71,7 @@ The following domains are globally allowed and can be fetched by any app:
 - cdn.espn.com
 - discord.com
 - api.polygon.io
+- api.massive.com
 - polygon.io
 - slack.com
 - lichess.org

--- a/docs/capabilities/server/http-fetch.mdx
+++ b/docs/capabilities/server/http-fetch.mdx
@@ -180,6 +180,7 @@ The following domains are globally allowed and can be fetched by any app:
 - cdn.espn.com
 - discord.com
 - api.polygon.io
+- api.massive.com
 - polygon.io
 - slack.com
 - lichess.org

--- a/versioned_docs/version-0.11/capabilities/http-fetch-allowlist.md
+++ b/versioned_docs/version-0.11/capabilities/http-fetch-allowlist.md
@@ -7,6 +7,7 @@ The following domains are globally allowed and can be fetched by any app:
 - cdn.espn.com
 - discord.com
 - api.polygon.io
+- api.massive.com
 - polygon.io
 - slack.com
 - lichess.org

--- a/versioned_docs/version-0.12/capabilities/server/http-fetch-policy.md
+++ b/versioned_docs/version-0.12/capabilities/server/http-fetch-policy.md
@@ -71,6 +71,7 @@ The following domains are globally allowed and can be fetched by any app:
 - cdn.espn.com
 - discord.com
 - api.polygon.io
+- api.massive.com
 - polygon.io
 - slack.com
 - lichess.org

--- a/versioned_docs/version-0.12/capabilities/server/http-fetch.mdx
+++ b/versioned_docs/version-0.12/capabilities/server/http-fetch.mdx
@@ -180,6 +180,7 @@ The following domains are globally allowed and can be fetched by any app:
 - cdn.espn.com
 - discord.com
 - api.polygon.io
+- api.massive.com
 - polygon.io
 - slack.com
 - lichess.org


### PR DESCRIPTION
Adds `api.massive.com` alongside references to its former name `api.polygon.io` in the global fetch allowlist.