### PR TITLE
Update image upload docs

### DIFF
--- a/docs/capabilities/server/media-uploads.mdx
+++ b/docs/capabilities/server/media-uploads.mdx
@@ -22,7 +22,7 @@ Enable the `media` permission in your `devvit.json` file.
 ```
 
 ## Using media uploads
-On the server, you can pass the URL of any remotely hosted image (even if its not hosted on Reddit) to the `media.upload` function. The media function will return a Reddit URL.
+On the server, you can pass the URL of any remotely hosted image (even if its not hosted on Reddit) to the `media.upload` function. This function will return a Reddit URL. Both HTTP and data URLs are supported.
 
 <Tabs>
   <TabItem value="web" label="Devvit Web">
@@ -50,9 +50,12 @@ On the server, you can pass the URL of any remotely hosted image (even if its no
 
 
 ## Limitations
-Supported file types are:
-- GIF
-- PNG
-- JPEG
 
-Maximum size is 20 MB.
+The following file types are supported, along with a corresponding maximum size limit:
+- JPEG, PNG, and WEBP: up to 20 MB
+- GIF: up to 100 MB
+
+### Notes
+
+- When uploading through a data URL, the size limit is 7.5 MB regardless of file type due to request size limits.
+- When uploading a WEBP image, it will be converted to JPEG. As such, the Reddit URL returned points to a JPEG image.


### PR DESCRIPTION
## 💸 TL;DR
Explicitly state we support data URLs and clarify upload size limits.

## 🧪 Testing Steps / Validation
`yarn start`

<img width="996" height="328" alt="Screenshot 2026-01-16 at 12 29 00 PM" src="https://github.com/user-attachments/assets/467f0d99-e08e-4864-82f3-2186a55d824e" />


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
