### PR TITLE
Add documentation for developer teams

### DIFF
--- a/docs/capabilities/server/settings-and-secrets.mdx
+++ b/docs/capabilities/server/settings-and-secrets.mdx
@@ -9,6 +9,10 @@ Settings come in two scopes:
 - **Subreddit settings**: Configurable by moderators for each installation
 - **Global settings & Secrets**: Set by developers and shared across all installations
 
+:::warning
+Local environment variables and `.env` files are read during playtesting only.
+:::
+
 ## Defining settings
 
 Settings are defined differently depending on whether you're using Devvit Web or Devvit Blocks.

--- a/docs/guides/tools/multiple_developers.mdx
+++ b/docs/guides/tools/multiple_developers.mdx
@@ -1,0 +1,25 @@
+---
+title: Multiple Developers
+---
+
+Multiple developers working on a single app can clash with each other's uploads during playtesting. This is due to the same playtest subreddit and app name being used.
+
+Local environment variables allow multiple developers to share a single codebase while each having separate playtest subreddits and app names.
+
+## Setup
+
+- Keep `devvit.json` in git
+- Use local environment variables per developer to override the local targets used by the Devvit CLI:
+  - `DEVVIT_SUBREDDIT` (where you playtest)
+  - `DEVVIT_APP_NAME` (the app name the CLI uses)
+- Alternatively, use a local `.env` file and ensure it's not committed by adding it to `.gitignore`
+
+This gives each developer an isolated development lane without forking the repository or repeatedly editing `devvit.json`.
+
+:::warning
+Local environment variables and `.env` files are read during playtesting only. For API keys and other sensitive values, use [Settings and Secrets](/capabilities/server/settings-and-secrets).
+:::
+
+## Why not remove `devvit.json` from git?
+
+`devvit.json` is part of the app's core configuration, including capabilities, entry points, and permissions. If it isn't versioned, teammates can drift out-of-sync due to mismatched configurations. Instead, keep `devvit.json` stable and use local environment overrides.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -286,6 +286,7 @@ const sidebars: SidebarsConfig = {
         "guides/tools/logs",
         "guides/tools/playtest",
         "guides/tools/ui_simulator",
+        "guides/tools/multiple_developers"
       ],
     },
     {

--- a/versioned_docs/version-0.12/capabilities/server/settings-and-secrets.mdx
+++ b/versioned_docs/version-0.12/capabilities/server/settings-and-secrets.mdx
@@ -9,6 +9,10 @@ Settings come in two scopes:
 - **Subreddit settings**: Configurable by moderators for each installation
 - **Global settings & Secrets**: Set by developers and shared across all installations
 
+:::warning
+Local environment variables and `.env` files are read during playtesting only.
+:::
+
 ## Defining settings
 
 Settings are defined differently depending on whether you're using Devvit Web or Devvit Blocks.

--- a/versioned_docs/version-0.12/guides/tools/multiple_developers.mdx
+++ b/versioned_docs/version-0.12/guides/tools/multiple_developers.mdx
@@ -1,0 +1,25 @@
+---
+title: Multiple Developers
+---
+
+Multiple developers working on a single app can clash with each other's uploads during playtesting. This is due to the same playtest subreddit and app name being used.
+
+Local environment variables allow multiple developers to share a single codebase while each having separate playtest subreddits and app names.
+
+## Setup
+
+- Keep `devvit.json` in git
+- Use local environment variables per developer to override the local targets used by the Devvit CLI:
+  - `DEVVIT_SUBREDDIT` (where you playtest)
+  - `DEVVIT_APP_NAME` (the app name the CLI uses)
+- Alternatively, use a local `.env` file and ensure it's not committed by adding it to `.gitignore`
+
+This gives each developer an isolated development lane without forking the repository or repeatedly editing `devvit.json`.
+
+:::warning
+Local environment variables and `.env` files are read during playtesting only. For API keys and other sensitive values, use [Settings and Secrets](/capabilities/server/settings-and-secrets).
+:::
+
+## Why not remove `devvit.json` from git?
+
+`devvit.json` is part of the app's core configuration, including capabilities, entry points, and permissions. If it isn't versioned, teammates can drift out-of-sync due to mismatched configurations. Instead, keep `devvit.json` stable and use local environment overrides.

--- a/versioned_sidebars/version-0.12-sidebars.json
+++ b/versioned_sidebars/version-0.12-sidebars.json
@@ -274,7 +274,8 @@
         "guides/tools/devvit_test",
         "guides/tools/logs",
         "guides/tools/playtest",
-        "guides/tools/ui_simulator"
+        "guides/tools/ui_simulator",
+        "guides/tools/multiple_developers"
       ]
     },
     {


### PR DESCRIPTION
Adds "Multiple Developers" page under Development Tools.

Updates "Settings and Secrets" page to explain `.env` is playtest only.