### PR TITLE
fix CI error that happens on each version bump

### DIFF
--- a/scripts/commit-docs-bump.sh
+++ b/scripts/commit-docs-bump.sh
@@ -2,6 +2,7 @@
 set -xeuo pipefail
 
 git checkout -b docs-release-$1
+yarn
 git add .
 git commit -m "v$1 release"
 git push --set-upstream origin docs-release-$1


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
Every time we create a release PR, first CI pass fails (example: https://github.com/reddit/devvit-docs/pull/99)
It's because yarn.lock needs to be updated
This PR adds a `yarn` step to the version bump script

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
