### PR TITLE
Add caution for duplicate trigger delivery

### DIFF
--- a/docs/capabilities/server/triggers.mdx
+++ b/docs/capabilities/server/triggers.mdx
@@ -156,3 +156,9 @@ router.post<string, never, TriggerResponse, OnPostSubmitRequest>(
 - Avoid creating recursive triggers that could cause infinite loops or crashes (for example, a comment trigger that creates a comment).
 - Always check the event payload to ensure your app is not the source of the event before taking action.
 - Review the [EventTypes documentation](../../api/public-api/@devvit/namespaces/EventTypes/) for details on event payloads.
+
+:::caution
+
+Triggers are not guaranteed to deliver only once for a single event. Ensure your app logic is able to handle this case, e.g. checking if content has been recently actioned before taking action again.
+
+:::

--- a/docs/capabilities/server/triggers.mdx
+++ b/docs/capabilities/server/triggers.mdx
@@ -158,7 +158,5 @@ router.post<string, never, TriggerResponse, OnPostSubmitRequest>(
 - Review the [EventTypes documentation](../../api/public-api/@devvit/namespaces/EventTypes/) for details on event payloads.
 
 :::caution
-
 Triggers are not guaranteed to deliver only once for a single event. Ensure your app logic is able to handle this case, e.g. checking if content has been recently actioned before taking action again.
-
 :::

--- a/versioned_docs/version-0.12/capabilities/server/triggers.mdx
+++ b/versioned_docs/version-0.12/capabilities/server/triggers.mdx
@@ -156,3 +156,9 @@ router.post<string, never, TriggerResponse, OnPostSubmitRequest>(
 - Avoid creating recursive triggers that could cause infinite loops or crashes (for example, a comment trigger that creates a comment).
 - Always check the event payload to ensure your app is not the source of the event before taking action.
 - Review the [EventTypes documentation](../../api/public-api/@devvit/namespaces/EventTypes/) for details on event payloads.
+
+:::caution
+
+Triggers are not guaranteed to deliver only once for a single event. Ensure your app logic is able to handle this case, e.g. checking if content has been recently actioned before taking action again.
+
+:::

--- a/versioned_docs/version-0.12/capabilities/server/triggers.mdx
+++ b/versioned_docs/version-0.12/capabilities/server/triggers.mdx
@@ -158,7 +158,5 @@ router.post<string, never, TriggerResponse, OnPostSubmitRequest>(
 - Review the [EventTypes documentation](../../api/public-api/@devvit/namespaces/EventTypes/) for details on event payloads.
 
 :::caution
-
 Triggers are not guaranteed to deliver only once for a single event. Ensure your app logic is able to handle this case, e.g. checking if content has been recently actioned before taking action again.
-
 :::


### PR DESCRIPTION
Explains that triggers can deliver multiple times with suggestion toward idempotency.