### PR TITLE
Fix caution for client library functions

### DIFF
--- a/docs/capabilities/client/overview.mdx
+++ b/docs/capabilities/client/overview.mdx
@@ -39,7 +39,7 @@ if (result) {
 | **Form** | Display interactive forms with promise-based responses | `showForm()` |
 | **Navigation** | Redirect to Reddit content or external URLs | `navigateTo()` |
 
-:::note When to use client library functions
+:::caution
 You should only use client library functions in response to a user-initiated action.
 :::
 

--- a/versioned_docs/version-0.12/capabilities/client/overview.mdx
+++ b/versioned_docs/version-0.12/capabilities/client/overview.mdx
@@ -39,7 +39,7 @@ if (result) {
 | **Form** | Display interactive forms with promise-based responses | `showForm()` |
 | **Navigation** | Redirect to Reddit content or external URLs | `navigateTo()` |
 
-:::note When to use client library functions
+:::caution
 You should only use client library functions in response to a user-initiated action.
 :::
 


### PR DESCRIPTION
The admonition is currently not rendering correctly, removes title and switches to `caution`.