### PR TITLE
Devvit docs csat widget v1

### DIFF
--- a/src/components/CsatWidget/index.tsx
+++ b/src/components/CsatWidget/index.tsx
@@ -1,0 +1,256 @@
+import clsx from 'clsx';
+import { useLocation } from '@docusaurus/router';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import styles from './styles.module.css';
+
+const CSAT_STORAGE_PREFIX = 'devvit_docs_csat_submitted:';
+
+declare global {
+  interface Window {
+    sendV2Event?: (event: unknown) => void;
+  }
+}
+
+function getStorageKey(pathname: string): string {
+  return `${CSAT_STORAGE_PREFIX}${pathname}`;
+}
+
+function getReferrerInfo(): { url?: string; domain?: string } {
+  if (!document.referrer) {
+    return {};
+  }
+
+  try {
+    const referrerUrl = new URL(document.referrer);
+    return {
+      url: document.referrer,
+      domain: referrerUrl.host,
+    };
+  } catch {
+    return {
+      url: document.referrer,
+    };
+  }
+}
+
+type ScoreOption = {
+  label: string;
+  value: number;
+  emoji: string;
+  reaction: 'positive' | 'negative';
+};
+
+const SCORE_OPTIONS: ScoreOption[] = [
+  {
+    label: 'Thumbs down',
+    value: 1,
+    emoji: '👎',
+    reaction: 'negative',
+  },
+  {
+    label: 'Thumbs up',
+    value: 5,
+    emoji: '👍',
+    reaction: 'positive',
+  },
+];
+
+const NEGATIVE_REASON_OPTIONS = [
+  'The page is unclear',
+  'Important details are missing',
+  'The instructions did not work',
+];
+
+export default function CsatWidget(): React.ReactElement | null {
+  const { pathname } = useLocation();
+  const [selectedScore, setSelectedScore] = useState<number | null>(null);
+  const [feedback, setFeedback] = useState('');
+  const [selectedReasons, setSelectedReasons] = useState<string[]>([]);
+  const [isVisible, setIsVisible] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const storageKey = useMemo(() => getStorageKey(pathname), [pathname]);
+  const shouldShowForPath = useMemo(() => {
+    const normalizedPath = pathname.replace(/\/+$/, '') || '/';
+    return normalizedPath !== '/' && normalizedPath !== '/docs';
+  }, [pathname]);
+
+  const sendEvent = (action: string, details: Record<string, unknown>) => {
+    if (typeof window === 'undefined' || typeof window.sendV2Event !== 'function') {
+      return;
+    }
+
+    window.sendV2Event({
+      source: 'docs_csat_widget',
+      action,
+      noun: 'csat',
+      action_info: {
+        page_type: 'dev_portal_docs',
+        page_path: pathname,
+        ...details,
+      },
+      request: {
+        base_url: window.location.href,
+      },
+      referrer: getReferrerInfo(),
+    });
+  };
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (!shouldShowForPath) {
+      setSelectedScore(null);
+      setFeedback('');
+      setSelectedReasons([]);
+      setIsSubmitted(false);
+      setIsVisible(false);
+      return;
+    }
+
+    const hasSubmitted = window.sessionStorage.getItem(storageKey) === '1';
+    setSelectedScore(null);
+    setFeedback('');
+    setSelectedReasons([]);
+    setIsSubmitted(false);
+    setIsVisible(!hasSubmitted);
+
+    if (!hasSubmitted) {
+      sendEvent('view', { widget: 'docs_csat' });
+    }
+  }, [storageKey, shouldShowForPath]);
+
+  const dismiss = () => {
+    sendEvent('dismiss', { widget: 'docs_csat' });
+    setIsVisible(false);
+  };
+
+  const submit = (score: number, extraDetails: Record<string, unknown> = {}) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    sendEvent('submit', {
+      widget: 'docs_csat',
+      score,
+      ...extraDetails,
+    });
+
+    window.sessionStorage.setItem(storageKey, '1');
+    setIsSubmitted(true);
+    window.setTimeout(() => {
+      setIsVisible(false);
+    }, 1200);
+  };
+
+  const onScoreSelect = (option: ScoreOption) => {
+    const score = option.value;
+    setSelectedScore(score);
+    if (option.reaction === 'positive') {
+      setSelectedReasons([]);
+      setFeedback('');
+    }
+
+    sendEvent('select_score', {
+      widget: 'docs_csat',
+      score,
+      reaction: option.reaction,
+    });
+
+    if (option.reaction === 'positive') {
+      submit(score, {
+        reaction: option.reaction,
+        feedback: '',
+        feedback_length: 0,
+        reasons: [],
+      });
+    }
+  };
+
+  const toggleReason = (reason: string) => {
+    setSelectedReasons((current) =>
+      current.includes(reason) ? current.filter((item) => item !== reason) : [...current, reason]
+    );
+  };
+
+  const submitNegativeFeedback = () => {
+    if (selectedScore !== 1) {
+      return;
+    }
+
+    const trimmedFeedback = feedback.trim();
+    submit(selectedScore, {
+      reaction: 'negative',
+      feedback: trimmedFeedback,
+      feedback_length: trimmedFeedback.length,
+      reasons: selectedReasons,
+    });
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className={styles.widget}>
+      <div className={styles.header}>
+        <p className={styles.title}>How helpful was this page?</p>
+        <button
+          className={styles.closeButton}
+          type="button"
+          aria-label="Close feedback widget"
+          onClick={dismiss}
+        >
+          &times;
+        </button>
+      </div>
+      <div className={styles.scoreRow}>
+        {SCORE_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            aria-label={option.label}
+            className={clsx(styles.scoreButton, {
+              [styles.scoreButtonSelected]: selectedScore === option.value,
+            })}
+            onClick={() => onScoreSelect(option)}
+          >
+            <span className={styles.scoreEmoji} aria-hidden>
+              {option.emoji}
+            </span>
+          </button>
+        ))}
+      </div>
+      {selectedScore === 1 && !isSubmitted && (
+        <div className={styles.feedback}>
+          <p className={styles.feedbackTitle}>Additional feedback (optional)</p>
+          <textarea
+            className={styles.textarea}
+            placeholder="Optional: what should we improve?"
+            value={feedback}
+            onChange={(event) => setFeedback(event.target.value)}
+          />
+          <div className={styles.reasonList}>
+            {NEGATIVE_REASON_OPTIONS.map((reason) => (
+              <label key={reason} className={styles.reasonItem}>
+                <input
+                  type="checkbox"
+                  checked={selectedReasons.includes(reason)}
+                  onChange={() => toggleReason(reason)}
+                />
+                <span>{reason}</span>
+              </label>
+            ))}
+          </div>
+          <button className={styles.submitButton} type="button" onClick={submitNegativeFeedback}>
+            Send feedback
+          </button>
+        </div>
+      )}
+      {isSubmitted && <div className={styles.thanks}>Thanks for the feedback!</div>}
+    </div>
+  );
+}

--- a/src/components/CsatWidget/styles.module.css
+++ b/src/components/CsatWidget/styles.module.css
@@ -1,0 +1,194 @@
+.widget {
+  --csat-accent-color: rgb(236, 85, 40);
+  width: min(640px, calc(100% - 2rem));
+  margin: 2rem auto 2.5rem;
+  padding: 1rem;
+  border-radius: var(--ifm-pagination-nav-border-radius, 8px);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: transparent;
+  box-shadow: none;
+  color: var(--ifm-font-color-base);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+}
+
+.closeButton {
+  border: none;
+  background: transparent;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 4px;
+  border-radius: 8px;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+
+.closeButton:hover {
+  color: var(--csat-accent-color);
+  background: color-mix(in srgb, var(--csat-accent-color) 10%, transparent);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid var(--csat-accent-color);
+  outline-offset: 2px;
+}
+
+.scoreRow {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.scoreButton {
+  flex: 1;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 14px 6px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 120ms ease, background-color 120ms ease, transform 120ms ease;
+}
+
+.scoreButton:hover {
+  border-color: var(--csat-accent-color);
+  background: color-mix(in srgb, var(--csat-accent-color) 10%, transparent);
+}
+
+.scoreButton:focus-visible {
+  outline: 2px solid var(--csat-accent-color);
+  outline-offset: 2px;
+}
+
+.scoreButtonSelected {
+  border-color: var(--csat-accent-color);
+  background: color-mix(in srgb, var(--csat-accent-color) 18%, transparent);
+}
+
+.scoreEmoji {
+  font-size: 32px;
+  line-height: 1;
+}
+
+.feedback {
+  margin-top: 12px;
+}
+
+.feedbackTitle {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+}
+
+.textarea {
+  width: 100%;
+  height: 74px;
+  border-radius: 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  color: inherit;
+  font-size: 13px;
+  padding: 10px;
+  resize: vertical;
+}
+
+.textarea:focus-visible {
+  border-color: var(--csat-accent-color);
+  outline: 2px solid color-mix(in srgb, var(--csat-accent-color) 40%, transparent);
+  outline-offset: 1px;
+}
+
+.reasonList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.reasonItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--ifm-font-color-base);
+}
+
+.reasonItem input[type='checkbox'] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  border: 1px solid var(--ifm-color-emphasis-400);
+  border-radius: 4px;
+  background: transparent;
+  display: inline-grid;
+  place-content: center;
+}
+
+.reasonItem input[type='checkbox']:checked {
+  border-color: var(--csat-accent-color);
+  background: var(--csat-accent-color);
+}
+
+.reasonItem input[type='checkbox']:checked::after {
+  content: '';
+  width: 10px;
+  height: 10px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M6.2 11.2 2.8 7.8l1.1-1.1 2.3 2.3 5.9-5.9 1.1 1.1z'/%3E%3C/svg%3E");
+}
+
+.reasonItem input[type='checkbox']:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--csat-accent-color) 40%, transparent);
+  outline-offset: 2px;
+}
+
+.submitButton {
+  margin-top: 12px;
+  border: 1px solid var(--csat-accent-color);
+  border-radius: 8px;
+  background: var(--csat-accent-color);
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 12px;
+  transition: filter 120ms ease, transform 120ms ease;
+}
+
+.submitButton:hover {
+  filter: brightness(0.95);
+}
+
+.submitButton:focus-visible {
+  outline: 2px solid var(--csat-accent-color);
+  outline-offset: 2px;
+}
+
+.thanks {
+  margin-top: 10px;
+  font-size: 13px;
+  color: var(--ifm-color-success);
+}

--- a/src/theme/DocsRoot/index.tsx
+++ b/src/theme/DocsRoot/index.tsx
@@ -1,0 +1,19 @@
+import type { Props } from '@theme/DocsRoot';
+import clsx from 'clsx';
+import React from 'react';
+import { HtmlClassNameProvider, ThemeClassNames } from '@docusaurus/theme-common';
+import renderRoutes from '@docusaurus/renderRoutes';
+import Layout from '@theme/Layout';
+
+import CsatWidget from '@site/src/components/CsatWidget';
+
+export default function DocsRoot(props: Props): React.ReactElement {
+  return (
+    <HtmlClassNameProvider className={clsx(ThemeClassNames.wrapper.docsPages)}>
+      <Layout>
+        {renderRoutes(props.route.routes)}
+        <CsatWidget />
+      </Layout>
+    </HtmlClassNameProvider>
+  );
+}

--- a/static/events.js
+++ b/static/events.js
@@ -20,6 +20,24 @@ window.sendV2Event = (event) => {
   });
 };
 
+function getReferrerInfo() {
+  if (!document.referrer) {
+    return {};
+  }
+
+  try {
+    const referrerUrl = new URL(document.referrer);
+    return {
+      url: document.referrer,
+      domain: referrerUrl.host,
+    };
+  } catch {
+    return {
+      url: document.referrer,
+    };
+  }
+}
+
 // Lovingly ripped off from client/src/lib/globalEventHandler.ts
 class GlobalEventHandler {
   #isVisible = true;
@@ -72,16 +90,8 @@ class GlobalEventHandler {
       request: {
         base_url: window.location.href,
       },
-      referrer: {},
+      referrer: getReferrerInfo(),
     };
-
-    if (document.referrer) {
-      const referrerUrl = new URL(document.referrer);
-      event.referrer = {
-        url: document.referrer,
-        domain: referrerUrl.host,
-      };
-    }
 
     window.sendV2Event(event);
   }


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
- Implemented a custom docs CSAT widget and wired it to the existing analytics transport for upstream reporting.
- Widget UX is a simplified 👍 / 👎 flow for now we can add snoos later if needed:
  - 👍 submits immediately
  - 👎 opens optional follow-up (textarea + 3 checkbox reasons)

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
Manually tested, need to verify metrics in prod after merge. 

<img width="700" height="212" alt="Screenshot 2026-05-21 at 2 08 16 PM" src="https://github.com/user-attachments/assets/cb99f36d-f282-4455-8880-956e4479ff15" />

<img width="742" height="471" alt="Screenshot 2026-05-21 at 2 08 23 PM" src="https://github.com/user-attachments/assets/c107975e-ca23-4c88-8c43-d656ad11f1fe" />
