### PR TITLE
updated permissions for preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: preview-pr-${{ github.event.issue.number }}
@@ -47,6 +47,7 @@ jobs:
 
       - name: React to preview request
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
           script: |
             await github.rest.reactions.createForIssueComment({

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,7 +6,7 @@ on:
       - created
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,7 +6,7 @@ on:
       - created
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
Changed workflow permission from pull-requests: read to pull-requests: write.
Added continue-on-error: true to React to preview request.
Reason: the rocket reaction is just a nice confirmation, so it should not block the preview build if GitHub rejects that API call with a 403.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
