### PR TITLE
Remove old http fetch policy refs

### DIFF
--- a/docs/capabilities/http-fetch.md
+++ b/docs/capabilities/http-fetch.md
@@ -36,7 +36,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 
 Domains that are approved for your app will be displayed in the Developer Settings section for your app at https://developers.reddit.com/apps/{your-app-slug}/developer-settings. These domains are allow-listed for **your app only** and not globally.
 
-Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](https://developers.reddit.com/docs/capabilities/server/http-fetch#global-fetch-allowlist) to view the list of globally allowed domains.
+Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 
 ## Limitations
 
@@ -208,7 +208,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 
 Domains that are approved for your app are displayed in the \[Developer Settings\](https://developers.reddit.com/apps/{your-app-slug}/developer-settings) section for your app. These domains are allow-listed for **your app only** and not globally.
 
-Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](https://developers.reddit.com/docs/capabilities/server/http-fetch-policy#global-fetch-allowlist) to view the list of globally allowed domains.
+Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 
 ### Terms and conditions
 

--- a/docs/capabilities/http-fetch.md
+++ b/docs/capabilities/http-fetch.md
@@ -34,7 +34,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 * No protocols: https://api.example.com  
 * No paths: api.example.com/webhooks
 
-Domains that are approved for your app will be displayed in the Developer Settings section for your app at https://developers.reddit.com/apps/{your-app-slug}/developer-settings. These domains are allow-listed for **your app only** and not globally.
+Domains that are approved for your app will be displayed in the Developer Settings section for your app at `https://developers.reddit.com/apps/{your-app-slug}/developer-settings`. These domains are allow-listed for **your app only** and not globally.
 
 Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 
@@ -206,7 +206,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 * No protocols: https://api.example.com  
 * No paths: api.example.com/webhooks
 
-Domains that are approved for your app are displayed in the \[Developer Settings\](https://developers.reddit.com/apps/{your-app-slug}/developer-settings) section for your app. These domains are allow-listed for **your app only** and not globally.
+Domains that are approved for your app are displayed in the Developer Settings section for your app at `https://developers.reddit.com/apps/{your-app-slug}/developer-settings`. These domains are allow-listed for **your app only** and not globally.
 
 Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 

--- a/docs/guides/faq.mdx
+++ b/docs/guides/faq.mdx
@@ -147,7 +147,7 @@ Most app versions are reviewed within **1–2 business days**. New apps or versi
 
 - **Payments**: apps using the payments capability go through additional policy review.
 - **`runAs: 'USER'`**: user action permissions require explicit approval as part of the review.
-- **External fetch domains**: new domain requests are reviewed separately and can add time (see [HTTP Fetch Policy](../capabilities/server/http-fetch-policy.md)).
+- **External fetch domains**: new domain requests are reviewed separately and can add time (see [HTTP Fetch](../capabilities/http-fetch.md)).
 
 To keep review moving:
 
@@ -418,10 +418,10 @@ Domain requests are reviewed separately from app publishing and can take **up to
 To make approval go smoothly:
 
 - Use exact hostnames only — no wildcards (`*.example.com`), no protocols (`https://`), and no paths (`api.example.com/webhooks`).
-- Add a "Fetch Domains" section to your `README.md` listing each domain and explaining why you need it. The expected format is documented in [HTTP Fetch Policy](../capabilities/server/http-fetch-policy.md).
+- Add a "Fetch Domains" section to your `README.md` listing each domain and explaining why you need it. The expected format is documented in [HTTP Fetch](../capabilities/http-fetch.md).
 - Include links to your Terms and Conditions and Privacy Policy in your app details form.
 
-Before submitting, check the [global fetch allowlist](../capabilities/server/http-fetch-policy.md#global-fetch-allowlist) — if your domain is already listed there, no separate request is needed. Personal domains (e.g., `personaldomain.com`) aren't approved.
+Before submitting, check the [global fetch allowlist](../capabilities/http-fetch.md#global-fetch-allowlist) — if your domain is already listed there, no separate request is needed. Personal domains (e.g., `personaldomain.com`) aren't approved.
 
 </details>
 

--- a/versioned_docs/version-0.11/capabilities/http-fetch.mdx
+++ b/versioned_docs/version-0.11/capabilities/http-fetch.mdx
@@ -49,7 +49,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 - No protocols: https://api.example.com
 - No paths: api.example.com/webhooks
 
-Domains that are approved for your app will be displayed in the Developer Settings section for your app at https://developers.reddit.com/apps/{your-app-slug}/developer-settings.
+Domains that are approved for your app will be displayed in the Developer Settings section for your app at `https://developers.reddit.com/apps/{your-app-slug}/developer-settings`.
 These domains are allow-listed for **your app only** and not globally.
 
 Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](./http-fetch-allowlist.md) to view the list of globally allowed domains.

--- a/versioned_docs/version-0.12/capabilities/http-fetch.md
+++ b/versioned_docs/version-0.12/capabilities/http-fetch.md
@@ -36,7 +36,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 
 Domains that are approved for your app will be displayed in the Developer Settings section for your app at https://developers.reddit.com/apps/{your-app-slug}/developer-settings. These domains are allow-listed for **your app only** and not globally.
 
-Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](https://developers.reddit.com/docs/capabilities/server/http-fetch#global-fetch-allowlist) to view the list of globally allowed domains.
+Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 
 ## Limitations
 
@@ -208,7 +208,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 
 Domains that are approved for your app are displayed in the \[Developer Settings\](https://developers.reddit.com/apps/{your-app-slug}/developer-settings) section for your app. These domains are allow-listed for **your app only** and not globally.
 
-Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](https://developers.reddit.com/docs/capabilities/server/http-fetch-policy#global-fetch-allowlist) to view the list of globally allowed domains.
+Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 
 ### Terms and conditions
 

--- a/versioned_docs/version-0.12/capabilities/http-fetch.md
+++ b/versioned_docs/version-0.12/capabilities/http-fetch.md
@@ -34,7 +34,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 * No protocols: https://api.example.com  
 * No paths: api.example.com/webhooks
 
-Domains that are approved for your app will be displayed in the Developer Settings section for your app at https://developers.reddit.com/apps/{your-app-slug}/developer-settings. These domains are allow-listed for **your app only** and not globally.
+Domains that are approved for your app will be displayed in the Developer Settings section for your app at `https://developers.reddit.com/apps/{your-app-slug}/developer-settings`. These domains are allow-listed for **your app only** and not globally.
 
 Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 
@@ -206,7 +206,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 * No protocols: https://api.example.com  
 * No paths: api.example.com/webhooks
 
-Domains that are approved for your app are displayed in the \[Developer Settings\](https://developers.reddit.com/apps/{your-app-slug}/developer-settings) section for your app. These domains are allow-listed for **your app only** and not globally.
+Domains that are approved for your app are displayed in the Developer Settings section for your app at `https://developers.reddit.com/apps/{your-app-slug}/developer-settings`. These domains are allow-listed for **your app only** and not globally.
 
 Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 

--- a/versioned_docs/version-0.12/guides/faq.mdx
+++ b/versioned_docs/version-0.12/guides/faq.mdx
@@ -147,7 +147,7 @@ Most app versions are reviewed within **1–2 business days**. New apps or versi
 
 - **Payments**: apps using the payments capability go through additional policy review.
 - **`runAs: 'USER'`**: user action permissions require explicit approval as part of the review.
-- **External fetch domains**: new domain requests are reviewed separately and can add time (see [HTTP Fetch Policy](../capabilities/server/http-fetch-policy.md)).
+- **External fetch domains**: new domain requests are reviewed separately and can add time (see [HTTP Fetch](../capabilities/http-fetch.md)).
 
 To keep review moving:
 
@@ -418,10 +418,10 @@ Domain requests are reviewed separately from app publishing and can take **up to
 To make approval go smoothly:
 
 - Use exact hostnames only — no wildcards (`*.example.com`), no protocols (`https://`), and no paths (`api.example.com/webhooks`).
-- Add a "Fetch Domains" section to your `README.md` listing each domain and explaining why you need it. The expected format is documented in [HTTP Fetch Policy](../capabilities/server/http-fetch-policy.md).
+- Add a "Fetch Domains" section to your `README.md` listing each domain and explaining why you need it. The expected format is documented in [HTTP Fetch](../capabilities/http-fetch.md).
 - Include links to your Terms and Conditions and Privacy Policy in your app details form.
 
-Before submitting, check the [global fetch allowlist](../capabilities/server/http-fetch-policy.md#global-fetch-allowlist) — if your domain is already listed there, no separate request is needed. Personal domains (e.g., `personaldomain.com`) aren't approved.
+Before submitting, check the [global fetch allowlist](../capabilities/http-fetch.md#global-fetch-allowlist) — if your domain is already listed there, no separate request is needed. Personal domains (e.g., `personaldomain.com`) aren't approved.
 
 </details>
 

--- a/versioned_docs/version-0.13/capabilities/http-fetch.md
+++ b/versioned_docs/version-0.13/capabilities/http-fetch.md
@@ -36,7 +36,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 
 Domains that are approved for your app will be displayed in the Developer Settings section for your app at https://developers.reddit.com/apps/{your-app-slug}/developer-settings. These domains are allow-listed for **your app only** and not globally.
 
-Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](https://developers.reddit.com/docs/capabilities/server/http-fetch#global-fetch-allowlist) to view the list of globally allowed domains.
+Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 
 ## Limitations
 
@@ -208,7 +208,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 
 Domains that are approved for your app are displayed in the \[Developer Settings\](https://developers.reddit.com/apps/{your-app-slug}/developer-settings) section for your app. These domains are allow-listed for **your app only** and not globally.
 
-Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](https://developers.reddit.com/docs/capabilities/server/http-fetch-policy#global-fetch-allowlist) to view the list of globally allowed domains.
+Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 
 ### Terms and conditions
 

--- a/versioned_docs/version-0.13/capabilities/http-fetch.md
+++ b/versioned_docs/version-0.13/capabilities/http-fetch.md
@@ -34,7 +34,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 * No protocols: https://api.example.com  
 * No paths: api.example.com/webhooks
 
-Domains that are approved for your app will be displayed in the Developer Settings section for your app at https://developers.reddit.com/apps/{your-app-slug}/developer-settings. These domains are allow-listed for **your app only** and not globally.
+Domains that are approved for your app will be displayed in the Developer Settings section for your app at `https://developers.reddit.com/apps/{your-app-slug}/developer-settings`. These domains are allow-listed for **your app only** and not globally.
 
 Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 
@@ -206,7 +206,7 @@ Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.or
 * No protocols: https://api.example.com  
 * No paths: api.example.com/webhooks
 
-Domains that are approved for your app are displayed in the \[Developer Settings\](https://developers.reddit.com/apps/{your-app-slug}/developer-settings) section for your app. These domains are allow-listed for **your app only** and not globally.
+Domains that are approved for your app are displayed in the Developer Settings section for your app at `https://developers.reddit.com/apps/{your-app-slug}/developer-settings`. These domains are allow-listed for **your app only** and not globally.
 
 Apps must request each individual domain that it intends to fetch, even if the domain is already globally allowed. See the [global fetch allowlist](#global-fetch-allowlist) to view the list of globally allowed domains.
 

--- a/versioned_docs/version-0.13/guides/faq.mdx
+++ b/versioned_docs/version-0.13/guides/faq.mdx
@@ -147,7 +147,7 @@ Most app versions are reviewed within **1–2 business days**. New apps or versi
 
 - **Payments**: apps using the payments capability go through additional policy review.
 - **`runAs: 'USER'`**: user action permissions require explicit approval as part of the review.
-- **External fetch domains**: new domain requests are reviewed separately and can add time (see [HTTP Fetch Policy](../capabilities/server/http-fetch-policy.md)).
+- **External fetch domains**: new domain requests are reviewed separately and can add time (see [HTTP Fetch](../capabilities/http-fetch.md)).
 
 To keep review moving:
 
@@ -418,10 +418,10 @@ Domain requests are reviewed separately from app publishing and can take **up to
 To make approval go smoothly:
 
 - Use exact hostnames only — no wildcards (`*.example.com`), no protocols (`https://`), and no paths (`api.example.com/webhooks`).
-- Add a "Fetch Domains" section to your `README.md` listing each domain and explaining why you need it. The expected format is documented in [HTTP Fetch Policy](../capabilities/server/http-fetch-policy.md).
+- Add a "Fetch Domains" section to your `README.md` listing each domain and explaining why you need it. The expected format is documented in [HTTP Fetch](../capabilities/http-fetch.md).
 - Include links to your Terms and Conditions and Privacy Policy in your app details form.
 
-Before submitting, check the [global fetch allowlist](../capabilities/server/http-fetch-policy.md#global-fetch-allowlist) — if your domain is already listed there, no separate request is needed. Personal domains (e.g., `personaldomain.com`) aren't approved.
+Before submitting, check the [global fetch allowlist](../capabilities/http-fetch.md#global-fetch-allowlist) — if your domain is already listed there, no separate request is needed. Personal domains (e.g., `personaldomain.com`) aren't approved.
 
 </details>
 


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

Removed all references and links to the old http-fetch-policy page.

Updated current docs and versioned 0.12 / 0.13 docs so:
-FAQ links point to http-fetch.md
-Allowlist links point to http-fetch.md#global-fetch-allowlist
-Internal HTTP Fetch allowlist links use #global-fetch-allowlist
-Verified with search: no stale http-fetch-policy references remain, and lints are clean.
