### PR TITLE
Add expected domain review times

### DIFF
--- a/docs/capabilities/http-fetch.md
+++ b/docs/capabilities/http-fetch.md
@@ -29,7 +29,7 @@ If you're porting a Data API app as part of our [App Migration Programs](https:/
 
 Apps may request a domain to be added to the allow-list by specifying domains in the http configuration. This configuration is optional, and apps can still configure http: true as before.
 
-Requested domains will be submitted for review when you playtest or upload your app. Admins may approve or deny domain requests.
+Requested domains will be submitted for review when you playtest or upload your app. Most domain requests are reviewed within **1–2 business days**, though requests with policy ambiguity may take longer. Admins may approve or deny domain requests.
 
 Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.org. These fetch requests are not allowed:
 

--- a/docs/capabilities/server/http-fetch.mdx
+++ b/docs/capabilities/server/http-fetch.mdx
@@ -23,7 +23,7 @@ Your Devvit app can make network requests to access allow-listed external domain
 Apps may request a domain to be added to the allow-list by specifying `domains` in the `http` configuration.
 This configuration is optional, and apps can still configure `http: true` as before.
 
-Requested domains will be submitted for review when you playtest or upload your app. Admins may approve or deny domain requests.
+Requested domains will be submitted for review when you playtest or upload your app. Most domain requests are reviewed within **1–2 business days**, though requests with policy ambiguity may take longer. Admins may approve or deny domain requests.
 
 Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.org. These fetch requests are not allowed:
 

--- a/docs/guides/faq.mdx
+++ b/docs/guides/faq.mdx
@@ -175,7 +175,7 @@ Most app versions are reviewed within **1–2 business days**. New apps or versi
 
 - **Payments**: apps using the payments capability go through additional policy review.
 - **`runAs: 'USER'`**: user action permissions require explicit approval as part of the review.
-- **External fetch domains**: new domain requests are reviewed separately and can add time (see [HTTP Fetch](../capabilities/http-fetch.md)).
+- **External fetch domains**: new domain requests are reviewed separately under the same **1–2 business day** target, though requests with policy ambiguity may take longer (see [HTTP Fetch](../capabilities/http-fetch.md)).
 
 To keep review moving:
 
@@ -439,7 +439,7 @@ If you need data to survive app updates, don't rely on browser `localStorage`. T
 <details>
 <summary>How long does it take to get my domain approved?</summary>
 
-Domain requests are reviewed separately from app publishing and can take **up to 4 business days**. If your app was approved but a requested fetch domain wasn't yet granted, the domain review may still be in progress.
+Domain requests are reviewed separately from app publishing. Most domain requests are reviewed within **1–2 business days**, though requests with policy ambiguity may take longer. If your app was approved but a requested fetch domain wasn't yet granted, the domain review may still be in progress.
 
 To make approval go smoothly:
 

--- a/versioned_docs/version-0.12/capabilities/http-fetch.md
+++ b/versioned_docs/version-0.12/capabilities/http-fetch.md
@@ -29,7 +29,7 @@ If you're porting a Data API app as part of our [App Migration Programs](https:/
 
 Apps may request a domain to be added to the allow-list by specifying domains in the http configuration. This configuration is optional, and apps can still configure http: true as before.
 
-Requested domains will be submitted for review when you playtest or upload your app. Admins may approve or deny domain requests.
+Requested domains will be submitted for review when you playtest or upload your app. Most domain requests are reviewed within **1–2 business days**, though requests with policy ambiguity may take longer. Admins may approve or deny domain requests.
 
 Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.org. These fetch requests are not allowed:
 

--- a/versioned_docs/version-0.12/capabilities/server/http-fetch.mdx
+++ b/versioned_docs/version-0.12/capabilities/server/http-fetch.mdx
@@ -23,7 +23,7 @@ Your Devvit app can make network requests to access allow-listed external domain
 Apps may request a domain to be added to the allow-list by specifying `domains` in the `http` configuration.
 This configuration is optional, and apps can still configure `http: true` as before.
 
-Requested domains will be submitted for review when you playtest or upload your app. Admins may approve or deny domain requests.
+Requested domains will be submitted for review when you playtest or upload your app. Most domain requests are reviewed within **1–2 business days**, though requests with policy ambiguity may take longer. Admins may approve or deny domain requests.
 
 Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.org. These fetch requests are not allowed:
 

--- a/versioned_docs/version-0.12/guides/faq.mdx
+++ b/versioned_docs/version-0.12/guides/faq.mdx
@@ -147,7 +147,7 @@ Most app versions are reviewed within **1–2 business days**. New apps or versi
 
 - **Payments**: apps using the payments capability go through additional policy review.
 - **`runAs: 'USER'`**: user action permissions require explicit approval as part of the review.
-- **External fetch domains**: new domain requests are reviewed separately and can add time (see [HTTP Fetch](../capabilities/http-fetch.md)).
+- **External fetch domains**: new domain requests are reviewed separately under the same **1–2 business day** target, though requests with policy ambiguity may take longer (see [HTTP Fetch](../capabilities/http-fetch.md)).
 
 To keep review moving:
 
@@ -411,7 +411,7 @@ If you need data to survive app updates, don't rely on browser `localStorage`. T
 <details>
 <summary>How long does it take to get my domain approved?</summary>
 
-Domain requests are reviewed separately from app publishing and can take **up to 4 business days**. If your app was approved but a requested fetch domain wasn't yet granted, the domain review may still be in progress.
+Domain requests are reviewed separately from app publishing. Most domain requests are reviewed within **1–2 business days**, though requests with policy ambiguity may take longer. If your app was approved but a requested fetch domain wasn't yet granted, the domain review may still be in progress.
 
 To make approval go smoothly:
 

--- a/versioned_docs/version-0.13/capabilities/http-fetch.md
+++ b/versioned_docs/version-0.13/capabilities/http-fetch.md
@@ -29,7 +29,7 @@ If you're porting a Data API app as part of our [App Migration Programs](https:/
 
 Apps may request a domain to be added to the allow-list by specifying domains in the http configuration. This configuration is optional, and apps can still configure http: true as before.
 
-Requested domains will be submitted for review when you playtest or upload your app. Admins may approve or deny domain requests.
+Requested domains will be submitted for review when you playtest or upload your app. Most domain requests are reviewed within **1–2 business days**, though requests with policy ambiguity may take longer. Admins may approve or deny domain requests.
 
 Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.org. These fetch requests are not allowed:
 

--- a/versioned_docs/version-0.13/capabilities/server/http-fetch.mdx
+++ b/versioned_docs/version-0.13/capabilities/server/http-fetch.mdx
@@ -23,7 +23,7 @@ Your Devvit app can make network requests to access allow-listed external domain
 Apps may request a domain to be added to the allow-list by specifying `domains` in the `http` configuration.
 This configuration is optional, and apps can still configure `http: true` as before.
 
-Requested domains will be submitted for review when you playtest or upload your app. Admins may approve or deny domain requests.
+Requested domains will be submitted for review when you playtest or upload your app. Most domain requests are reviewed within **1–2 business days**, though requests with policy ambiguity may take longer. Admins may approve or deny domain requests.
 
 Domain entries must be exact hostnames only, such as nytimes.com or wikipedia.org. These fetch requests are not allowed:
 

--- a/versioned_docs/version-0.13/guides/faq.mdx
+++ b/versioned_docs/version-0.13/guides/faq.mdx
@@ -175,7 +175,7 @@ Most app versions are reviewed within **1–2 business days**. New apps or versi
 
 - **Payments**: apps using the payments capability go through additional policy review.
 - **`runAs: 'USER'`**: user action permissions require explicit approval as part of the review.
-- **External fetch domains**: new domain requests are reviewed separately and can add time (see [HTTP Fetch](../capabilities/http-fetch.md)).
+- **External fetch domains**: new domain requests are reviewed separately under the same **1–2 business day** target, though requests with policy ambiguity may take longer (see [HTTP Fetch](../capabilities/http-fetch.md)).
 
 To keep review moving:
 
@@ -439,7 +439,7 @@ If you need data to survive app updates, don't rely on browser `localStorage`. T
 <details>
 <summary>How long does it take to get my domain approved?</summary>
 
-Domain requests are reviewed separately from app publishing and can take **up to 4 business days**. If your app was approved but a requested fetch domain wasn't yet granted, the domain review may still be in progress.
+Domain requests are reviewed separately from app publishing. Most domain requests are reviewed within **1–2 business days**, though requests with policy ambiguity may take longer. If your app was approved but a requested fetch domain wasn't yet granted, the domain review may still be in progress.
 
 To make approval go smoothly:
 


### PR DESCRIPTION
Adds expectations around domain review times, currently 1-2 business days, with a definition of when this may take longer.