### PR TITLE
redis storage update and media upload faq

### DIFF
--- a/docs/capabilities/client/forms.mdx
+++ b/docs/capabilities/client/forms.mdx
@@ -459,9 +459,10 @@ const imageField = {
 
 #### Notes
 
-- The formats supported are PNG, JPEG, WEBP, and GIF.
-- The maximum file size allowed is 20 MB.
-- When uploading a WEBP image, it will be converted to JPEG. As such, the Reddit URL returned points to a JPEG image.
+- Supported image formats: PNG, JPEG, WEBP, and GIF.
+- Maximum file size: 20 MB.
+- Upload timeout: 30 seconds. Files close to 10 MB or larger can fail on slower networks.
+- WEBP uploads are converted to JPEG. The returned Reddit URL points to a JPEG image.
 
 ### Group
 

--- a/docs/capabilities/server/media-uploads.mdx
+++ b/docs/capabilities/server/media-uploads.mdx
@@ -203,4 +203,5 @@ app.post('/api/upload-screenshot', async (c) => {
 
 - Supported image upload formats: PNG, JPEG, WEBP, and GIF.
 - Maximum upload size: 20 MB.
+- Upload timeout: 30 seconds. Files close to 10 MB or larger can fail on slower networks.
 - WEBP uploads may be converted to JPEG in the returned Reddit URL.

--- a/docs/capabilities/server/redis.mdx
+++ b/docs/capabilities/server/redis.mdx
@@ -64,7 +64,7 @@ For command-specific behavior and limits, see the [supported Redis commands](htt
 
 ## Storage values
 
-Redis is best for small, frequently accessed app states. Each Redis installation has a 500 MB storage limit and a 5 MB request size limit. 
+Redis is best for small, frequently accessed app states. Each Redis installation has a 5 MB request size limit. On occasion, apps will run into storage limits. Our team will reach out to you if this occurs and work with you to optimize your app.
 
 If your app stores large JSON objects, long text values, or historical records that still belong in Redis, use`redisCompressed`. 
 
@@ -106,9 +106,9 @@ Transactions are limited to 30 concurrent transaction blocks per installation, a
 
 For more details, see [Transactions](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#transactions).
 
-## Quota failures
+## Storage limit failures
 
-When an installation reaches the Redis storage limit, write operations can fail. Treat Redis writes as operations that may need a user-facing fallback.
+If an installation runs into storage limits, write operations can fail. Treat Redis writes as operations that may need a user-facing fallback.
 
 A good failure path should:
 
@@ -168,7 +168,6 @@ Design around these limits early so your app stays responsive as more people use
 | :---- | :---- | :---- |
 | Command throughput | 40,000 commands per second per installation | Avoid one Redis call per item in hot loops. Use batch commands such as `mGet`, `mSet`, and `hash` writes where they fit. |
 | Pipelining | Not supported | Reduce round trips by grouping related fields under hashes or compact JSON values. |
-| Storage | 500 MB per installation | Use `redisCompressed` for large values, expire temporary data, and cap unbounded histories. |
 | Request size | 5 MB | Store large datasets as multiple records and process them in batches. |
 | Transactions | 20 concurrent transaction blocks; 5-second execution timeout | Keep transaction logic small and release transactions with `exec`, `discard`, or `unwatch`. |
 

--- a/docs/guides/faq.mdx
+++ b/docs/guides/faq.mdx
@@ -294,6 +294,16 @@ See [Forms](../capabilities/client/forms.mdx) and [Media uploads](../capabilitie
 
 </details>
 
+<span id="why-do-image-uploads-over-10-mb-fail-if-the-limit-is-20-mb"></span>
+<details>
+<summary>Why do image uploads over 10 MB fail if the limit is 20 MB?</summary>
+
+Media uploads have both a 20 MB maximum upload size and a 30-second timeout. Files close to 10 MB or larger can still fail on slower networks if the upload does not finish before the timeout.
+
+Try compressing the image, reducing dimensions, or retrying from a faster connection.
+
+</details>
+
 <span id="what-image-urls-can-i-use-in-a-devvit-app"></span>
 <details>
 <summary>What image URLs can I use in a Devvit app?</summary>
@@ -424,7 +434,7 @@ You can also edit the display name, about description, and mature flag (18+) fie
 
 There's no single limits page today, but these are the most commonly referenced numbers in the docs:
 
-- [Redis](../capabilities/server/redis.mdx): 500 MB max storage per installation, 5 MB max request size, and 40,000 max commands per second.
+- [Redis](../capabilities/server/redis.mdx): 5 MB max request size and 40,000 max commands per second.
 - [Devvit Web](../capabilities/devvit-web/devvit_web_overview.mdx): 30 second max request time, 4 MB max payload size, and 10 MB max response size.
 - [Post data](../capabilities/server/post-data.mdx): 2 KB per post.
 - [Settings and secrets](../capabilities/server/settings-and-secrets.mdx): 2 KB per setting value.

--- a/versioned_docs/version-0.13/capabilities/client/forms.mdx
+++ b/versioned_docs/version-0.13/capabilities/client/forms.mdx
@@ -459,9 +459,10 @@ const imageField = {
 
 #### Notes
 
-- The formats supported are PNG, JPEG, WEBP, and GIF.
-- The maximum file size allowed is 20 MB.
-- When uploading a WEBP image, it will be converted to JPEG. As such, the Reddit URL returned points to a JPEG image.
+- Supported image formats: PNG, JPEG, WEBP, and GIF.
+- Maximum file size: 20 MB.
+- Upload timeout: 30 seconds. Files close to 10 MB or larger can fail on slower networks.
+- WEBP uploads are converted to JPEG. The returned Reddit URL points to a JPEG image.
 
 ### Group
 

--- a/versioned_docs/version-0.13/capabilities/server/media-uploads.mdx
+++ b/versioned_docs/version-0.13/capabilities/server/media-uploads.mdx
@@ -203,4 +203,5 @@ app.post('/api/upload-screenshot', async (c) => {
 
 - Supported image upload formats: PNG, JPEG, WEBP, and GIF.
 - Maximum upload size: 20 MB.
+- Upload timeout: 30 seconds. Files close to 10 MB or larger can fail on slower networks.
 - WEBP uploads may be converted to JPEG in the returned Reddit URL.

--- a/versioned_docs/version-0.13/capabilities/server/redis.mdx
+++ b/versioned_docs/version-0.13/capabilities/server/redis.mdx
@@ -64,7 +64,7 @@ For command-specific behavior and limits, see the [supported Redis commands](htt
 
 ## Storage values
 
-Redis is best for small, frequently accessed app states. Each Redis installation has a 500 MB storage limit and a 5 MB request size limit. 
+Redis is best for small, frequently accessed app states. Each Redis installation has a 5 MB request size limit. On occasion, apps will run into storage limits. Our team will reach out to you if this occurs and work with you to optimize your app.
 
 If your app stores large JSON objects, long text values, or historical records that still belong in Redis, use`redisCompressed`. 
 
@@ -106,9 +106,9 @@ Transactions are limited to 30 concurrent transaction blocks per installation, a
 
 For more details, see [Transactions](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#transactions).
 
-## Quota failures
+## Storage limit failures
 
-When an installation reaches the Redis storage limit, write operations can fail. Treat Redis writes as operations that may need a user-facing fallback.
+If an installation runs into storage limits, write operations can fail. Treat Redis writes as operations that may need a user-facing fallback.
 
 A good failure path should:
 
@@ -168,7 +168,6 @@ Design around these limits early so your app stays responsive as more people use
 | :---- | :---- | :---- |
 | Command throughput | 40,000 commands per second per installation | Avoid one Redis call per item in hot loops. Use batch commands such as `mGet`, `mSet`, and `hash` writes where they fit. |
 | Pipelining | Not supported | Reduce round trips by grouping related fields under hashes or compact JSON values. |
-| Storage | 500 MB per installation | Use `redisCompressed` for large values, expire temporary data, and cap unbounded histories. |
 | Request size | 5 MB | Store large datasets as multiple records and process them in batches. |
 | Transactions | 20 concurrent transaction blocks; 5-second execution timeout | Keep transaction logic small and release transactions with `exec`, `discard`, or `unwatch`. |
 

--- a/versioned_docs/version-0.13/guides/faq.mdx
+++ b/versioned_docs/version-0.13/guides/faq.mdx
@@ -294,6 +294,16 @@ See [Forms](../capabilities/client/forms.mdx) and [Media uploads](../capabilitie
 
 </details>
 
+<span id="why-do-image-uploads-over-10-mb-fail-if-the-limit-is-20-mb"></span>
+<details>
+<summary>Why do image uploads over 10 MB fail if the limit is 20 MB?</summary>
+
+Media uploads have both a 20 MB maximum upload size and a 30-second timeout. Files close to 10 MB or larger can still fail on slower networks if the upload does not finish before the timeout.
+
+Try compressing the image, reducing dimensions, or retrying from a faster connection.
+
+</details>
+
 <span id="what-image-urls-can-i-use-in-a-devvit-app"></span>
 <details>
 <summary>What image URLs can I use in a Devvit app?</summary>
@@ -424,7 +434,7 @@ You can also edit the display name, about description, and mature flag (18+) fie
 
 There's no single limits page today, but these are the most commonly referenced numbers in the docs:
 
-- [Redis](../capabilities/server/redis.mdx): 500 MB max storage per installation, 5 MB max request size, and 40,000 max commands per second.
+- [Redis](../capabilities/server/redis.mdx): 5 MB max request size and 40,000 max commands per second.
 - [Devvit Web](../capabilities/devvit-web/devvit_web_overview.mdx): 30 second max request time, 4 MB max payload size, and 10 MB max response size.
 - [Post data](../capabilities/server/post-data.mdx): 2 KB per post.
 - [Settings and secrets](../capabilities/server/settings-and-secrets.mdx): 2 KB per setting value.


### PR DESCRIPTION

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

Removed the explicit Redis 500 MB storage limit from the docs and replaced it with softer guidance that the team will reach out if an app hits storage limits.
Added/updated media upload guidance to say uploads have both:
20 MB max file size
30-second timeout
files around 10 MB+ may fail on slow networks
Also added a FAQ for the “why does 10 MB fail if docs say 20 MB?” case, and made the Forms image notes more direct and consistent.