### PR TITLE
Update Settings & Secrets in sidebar to be a top level item

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -184,11 +184,6 @@ const sidebars: SidebarsConfig = {
       id: "capabilities/http-fetch",
     },
     {
-      type: "doc",
-      label: "Settings & Secrets",
-      id: "capabilities/server/settings-and-secrets",
-    },
-    {
       type: "category",
       label: "In-App Purchases",
       items: [
@@ -269,6 +264,11 @@ const sidebars: SidebarsConfig = {
           ],
         },
       ],
+    },
+    {
+      type: "doc",
+      label: "Settings & Secrets",
+      id: "capabilities/server/settings-and-secrets",
     },
     {
       type: "category",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -184,6 +184,11 @@ const sidebars: SidebarsConfig = {
       id: "capabilities/http-fetch",
     },
     {
+      type: "doc",
+      label: "Settings & Secrets",
+      id: "capabilities/server/settings-and-secrets",
+    },
+    {
       type: "category",
       label: "In-App Purchases",
       items: [
@@ -211,7 +216,6 @@ const sidebars: SidebarsConfig = {
        "capabilities/client/navigation",
         "capabilities/client/toasts",
         "capabilities/client/menu-actions",
-        "capabilities/server/settings-and-secrets",
         "capabilities/server/launch_screen_and_entry_points/view_modes_entry_points",
         {
           type: "category",

--- a/versioned_sidebars/version-0.12-sidebars.json
+++ b/versioned_sidebars/version-0.12-sidebars.json
@@ -150,6 +150,11 @@
       "id": "capabilities/http-fetch"
     },
     {
+      "type": "doc",
+      "label": "Settings & Secrets",
+      "id": "capabilities/server/settings-and-secrets"
+    },
+    {
       "type": "category",
       "label": "In-App Purchases",
       "items": [
@@ -169,7 +174,6 @@
         "capabilities/client/navigation",
         "capabilities/client/toasts",
         "capabilities/client/menu-actions",
-        "capabilities/server/settings-and-secrets",
         "capabilities/server/launch_screen_and_entry_points/view_modes_entry_points",
         {
           "type": "category",

--- a/versioned_sidebars/version-0.12-sidebars.json
+++ b/versioned_sidebars/version-0.12-sidebars.json
@@ -150,11 +150,6 @@
       "id": "capabilities/http-fetch"
     },
     {
-      "type": "doc",
-      "label": "Settings & Secrets",
-      "id": "capabilities/server/settings-and-secrets"
-    },
-    {
       "type": "category",
       "label": "In-App Purchases",
       "items": [
@@ -229,6 +224,11 @@
           ]
         }
       ]
+    },
+    {
+      "type": "doc",
+      "label": "Settings & Secrets",
+      "id": "capabilities/server/settings-and-secrets"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-0.13-sidebars.json
+++ b/versioned_sidebars/version-0.13-sidebars.json
@@ -169,11 +169,6 @@
       "id": "capabilities/http-fetch"
     },
     {
-      "type": "doc",
-      "label": "Settings & Secrets",
-      "id": "capabilities/server/settings-and-secrets"
-    },
-    {
       "type": "category",
       "label": "In-App Purchases",
       "items": [
@@ -257,6 +252,11 @@
           ]
         }
       ]
+    },
+    {
+      "type": "doc",
+      "label": "Settings & Secrets",
+      "id": "capabilities/server/settings-and-secrets"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-0.13-sidebars.json
+++ b/versioned_sidebars/version-0.13-sidebars.json
@@ -169,6 +169,11 @@
       "id": "capabilities/http-fetch"
     },
     {
+      "type": "doc",
+      "label": "Settings & Secrets",
+      "id": "capabilities/server/settings-and-secrets"
+    },
+    {
       "type": "category",
       "label": "In-App Purchases",
       "items": [
@@ -197,7 +202,6 @@
         "capabilities/client/navigation",
         "capabilities/client/toasts",
         "capabilities/client/menu-actions",
-        "capabilities/server/settings-and-secrets",
         "capabilities/server/launch_screen_and_entry_points/view_modes_entry_points",
         {
           "type": "category",


### PR DESCRIPTION
This enables quick access to `Settings & Secrets` by promoting it out of `Post Creation & Navigation`