### PR TITLE
Synchronize Devvit documentation with current behavior

### DIFF
--- a/docs/capabilities/devvit-web/devvit_web_configuration.md
+++ b/docs/capabilities/devvit-web/devvit_web_configuration.md
@@ -1,6 +1,6 @@
 # Configure your app
 
-The devvit.json file serves as your app's configuration file. Use it to specify entry points, configure features like [event triggers](../server/triggers) and [scheduled actions](../server/scheduler.mdx), and enable app functionality such as [image uploads](../server/media-uploads.mdx). This page covers all available devvit.json configuration options. A complete devvit.json example file is provided [here](#complete-example).
+The `devvit.json` file serves as your app's configuration file. Use it to specify entry points, configure features like [event triggers](../server/triggers) and [scheduled actions](../server/scheduler.mdx), and enable app functionality such as [image uploads](../server/media-uploads.mdx). This page summarizes the schema-supported configuration options; the published JSON Schema remains authoritative. A representative `devvit.json` example is provided [here](#complete-example).
 
 ## devvit.json
 
@@ -18,12 +18,13 @@ All configuration files should include a `$schema` property which many IDEs will
 
 Your `devvit.json` must include:
 
-- **`name`** (required): App account name and Community URL slug. Must be 3-16 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens.
+- **`name`** (required): App account name and Community URL slug. Must be 3-20 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens.
 
 Additionally, you must include at least one of:
 
 - **`post`**: For web view apps
 - **`server`**: For Node.js server apps
+- **`blocks`**: Deprecated migration configuration for legacy Blocks apps
 
 ## Configuration sections
 
@@ -31,15 +32,16 @@ Additionally, you must include at least one of:
 
 | Property  | Type   | Description                                                               | Required         |
 | --------- | ------ | ------------------------------------------------------------------------- | ---------------- |
-| `name`    | string | App account name and Community URL slug (3-16 chars, `^[a-z][a-z0-9-]*$`) | Yes              |
+| `name`    | string | App account name and Community URL slug (3-20 chars, `^[a-z][a-z0-9-]*$`) | Yes              |
 | `$schema` | string | Schema version for IDE support                                            | No (recommended) |
 
 ### App components
 
-| Property | Type   | Description                        | Required           |
-| -------- | ------ | ---------------------------------- | ------------------ |
-| `post`   | object | Custom post/web view configuration | One of post/server |
-| `server` | object | Node.js server configuration       | One of post/server |
+| Property | Type   | Description                                      | Required                  |
+| -------- | ------ | ------------------------------------------------ | ------------------------- |
+| `post`   | object | Custom post/web view configuration               | One of post/server/blocks |
+| `server` | object | Node.js server configuration                     | One of post/server/blocks |
+| `blocks` | object | Deprecated configuration for migrating Blocks apps | One of post/server/blocks |
 
 ### Permissions & capabilities
 
@@ -58,17 +60,19 @@ Additionally, you must include at least one of:
 
 ### UI & interaction
 
-| Property | Type   | Description                               | Required |
-| -------- | ------ | ----------------------------------------- | -------- |
-| `menu`   | object | Menu items in posts, comments, subreddits | No       |
-| `forms`  | object | Form submission endpoints                 | No       |
+| Property   | Type   | Description                                      | Required |
+| ---------- | ------ | ------------------------------------------------ | -------- |
+| `menu`     | object | Menu items in posts, comments, and subreddits    | No       |
+| `forms`    | object | Form submission endpoints                        | No       |
+| `settings` | object | Global and per-subreddit app settings definitions | No       |
 
 ### Development
 
-| Property  | Type   | Description                                         | Required |
-| --------- | ------ | --------------------------------------------------- | -------- |
-| `dev`     | object | Development configuration                           | No       |
-| `scripts` | object | Build commands run by the Devvit CLI (optional)     | No       |
+| Property        | Type   | Description                                             | Required |
+| --------------- | ------ | ------------------------------------------------------- | -------- |
+| `dev`           | object | Development configuration                               | No       |
+| `scripts`       | object | Build commands run by the Devvit CLI                     | No       |
+| `sourceIgnores` | array  | Source files excluded from packages submitted for review | No       |
 
 ## Detailed configuration
 
@@ -96,7 +100,7 @@ Configure web views for custom post types:
 - `entrypoints` (object): Map of named entrypoints for post rendering
   - Must include a `"default"` entrypoint
   - `entry` (string): HTML file path or `/api/` endpoint
-  - `height` (enum): `"regular"` or `"tall"` (default: `"regular"`)
+  - `height` (enum): `"regular"` or `"tall"` (default: `"tall"`)
 
 ### Server configuration
 
@@ -105,14 +109,17 @@ Configure Node.js server functionality:
 ```json
 {
   "server": {
-    "entry": "src/server/index.js"
+    "dir": "dist/server",
+    "entry": "index.js"
   }
 }
 ```
 
 **Properties:**
 
-- `entry` (string): Server bundle filename (default: `"src/server/index.js"`)
+- `dir` (string): Server bundle directory relative to the project root (default: `"dist/server"`)
+- `entry` (string): Server bundle filename within `server.dir` (default: `"index.js"`)
+- `externalEndpoints` (object): Named `/external/` routes available to approved outside callers. See [External Endpoints](../server/external-endpoints.mdx).
 
 Server bundles must be compiled to CommonJS (`cjs`). ES module output is not supported by the Devvit Web runtime.
 
@@ -128,9 +135,11 @@ Control what your app can access:
       "domains": ["example.com", "api.github.com"]
     },
     "media": true,
+    "journeys": true,
     "payments": false,
     "realtime": false,
     "redis": true,
+    "chromeless": false,
     "reddit": {
       "enable": true,
       "asUser": ["SUBMIT_POST", "SUBMIT_COMMENT"]
@@ -153,9 +162,12 @@ Control what your app can access:
 **Other permissions:**
 
 - `media` (boolean): Enable media uploads (default: `false`)
-- `payments` (boolean): Enable payments plugin (default: `false`)
+- `journeys` (boolean): Enable [Devvit Journeys](../analytics/devvit-journeys.md) telemetry (default: `false`)
+- `payments` (boolean): Enable the payments plugin (default: `false`)
 - `realtime` (boolean): Enable realtime messaging (default: `false`)
 - `redis` (boolean): Enable Redis storage (default: `false`)
+- `chromeless` (boolean): Allow supported custom posts to render without standard post chrome when highlighted (default: `false`)
+- `blob` (boolean): Reserved for the experimental Blob Storage capability and not yet publicly available. Follow the current [Blob Storage](../server/blob-storage.mdx) setup instructions rather than enabling this field unless directed by Reddit.
 
 ### Triggers configuration
 
@@ -176,6 +188,7 @@ Handle Reddit events:
 - `onAppInstall`, `onAppUpgrade`
 - `onPostCreate`, `onPostDelete`, `onPostSubmit`, `onPostUpdate`, `onPostReport`, `onPostFlairUpdate`, `onPostNsfwUpdate`, `onPostSpoilerUpdate`
 - `onCommentCreate`, `onCommentDelete`, `onCommentSubmit`, `onCommentUpdate`, `onCommentReport`
+- `onMentionInCommentCreate` (limited access; see [Global Triggers](../server/global-triggers.mdx))
 - `onModAction`, `onModMail`
 - `onAutomoderatorFilterPost`, `onAutomoderatorFilterComment`
 
@@ -264,6 +277,66 @@ Map form identifiers to submission endpoints:
 }
 ```
 
+### Static asset configuration
+
+Configure a directory of static assets that is available to both the app client and server:
+
+```json
+{
+  "media": {
+    "dir": "assets"
+  }
+}
+```
+
+- `dir` (string): Static asset directory relative to the project root (default: `"assets"`)
+
+This top-level `media` object is separate from `permissions.media`, which enables runtime media uploads.
+
+### Settings configuration
+
+Define settings that apply globally or can be configured separately for each subreddit installation:
+
+```json
+{
+  "settings": {
+    "global": {
+      "featureEnabled": {
+        "type": "boolean",
+        "label": "Enable feature",
+        "defaultValue": true
+      }
+    },
+    "subreddit": {
+      "welcomeMessage": {
+        "type": "paragraph",
+        "label": "Welcome message"
+      }
+    }
+  }
+}
+```
+
+At least one of `global` or `subreddit` is required. Supported setting types include strings, paragraphs, numbers, booleans, selects, and multi-selects. See [Settings and Secrets](../server/settings-and-secrets.mdx) for validation and access patterns.
+
+### Payments configuration
+
+The top-level `payments` object declares products and the internal endpoints used to fulfill or refund orders. It is separate from `permissions.payments`, which enables the payments plugin.
+
+```json
+{
+  "payments": {
+    "productsFile": "products.json",
+    "endpoints": {
+      "fulfillOrder": "/internal/payments/fulfill-order",
+      "refundOrder": "/internal/payments/refund-order"
+    }
+  }
+}
+```
+
+Provide either inline `products` or a `productsFile`, and always configure `endpoints.fulfillOrder`. See [Add Payments](../../earn-money/payments/payments_add.mdx) for the complete product schema and implementation steps.
+
 ### Marketing assets
 
 Configure app presentation:
@@ -298,6 +371,18 @@ Configure build commands run by the Devvit CLI. These commands run relative to t
 - `dev` (string): Command run by `devvit playtest` to build or watch your client/server artifacts
 - `build` (string): Command run by `devvit upload` to build your client/server artifacts
 
+### Source packaging exclusions
+
+Use `sourceIgnores` to exclude files from the source archive submitted during `devvit publish`. Patterns use `.gitignore` syntax and are evaluated after the root `.gitignore` file.
+
+```json
+{
+  "sourceIgnores": ["coverage/", "*.log", "fixtures/private/"]
+}
+```
+
+Patterns are relative to the project root. Some paths, including `node_modules/`, `.env`, and `.git/`, are always excluded.
+
 ### Development configuration
 
 Configure development settings:
@@ -316,11 +401,11 @@ Configure development settings:
 
 ## Validation rules
 
-The `devvit.json` configuration is validated against the JSON Schema at build time. Many IDEs will also underline errors as you write. Common validation errors include:
+The Devvit CLI validates `devvit.json` against the JSON Schema before playtest, upload, and publish operations. Many IDEs will also underline errors as you write. Common validation errors include:
 
 - **JSON Syntax:** Adding comments or trailing commas (unsupported by JSON)
 - **Required Properties:** Missing the required `name` property
-- **App Components:** Missing at least one of `post` or `server`
+- **App Components:** Missing at least one of `post` or `server` (or deprecated `blocks` migration configuration)
 - **Dependencies:** Missing `server` when `triggers` is specified
 - **File References:** Missing files referenced in `devvit.json`
 - **Permissions:** Missing required permissions for used features
@@ -333,7 +418,7 @@ The `devvit.json` configuration is validated against the JSON Schema at build ti
 3. **Set appropriate menu scopes.** Consider whether features should be available to all users or just moderators.
 4. **Validate endpoints.** Ensure all internal endpoints start with `/internal/`.
 5. **Use meaningful names.** Choose descriptive names for entrypoints, tasks, and forms.
-6. **Test configurations.** Validate your config with `devvit build` before deployment.
+6. **Test configurations.** Use `devvit playtest` during development; `devvit playtest`, `devvit upload`, and `devvit publish` validate the configuration before packaging.
 
 ## Environment variables
 
@@ -356,7 +441,8 @@ The `devvit.json` configuration is validated against the JSON Schema at build ti
     }
   },
   "server": {
-    "entry": "src/server/index.js"
+    "dir": "dist/server",
+    "entry": "index.js"
   },
   "permissions": {
     "http": {

--- a/docs/capabilities/devvit-web/devvit_web_configuration.md
+++ b/docs/capabilities/devvit-web/devvit_web_configuration.md
@@ -1,4 +1,4 @@
-# Configure your app
+﻿# Configure your app
 
 The `devvit.json` file serves as your app's configuration file. Use it to specify entry points, configure features like [event triggers](../server/triggers) and [scheduled actions](../server/scheduler.mdx), and enable app functionality such as [image uploads](../server/media-uploads.mdx). This page summarizes the schema-supported configuration options; the published JSON Schema remains authoritative. A representative `devvit.json` example is provided [here](#complete-example).
 
@@ -24,7 +24,6 @@ Additionally, you must include at least one of:
 
 - **`post`**: For web view apps
 - **`server`**: For Node.js server apps
-- **`blocks`**: Deprecated migration configuration for legacy Blocks apps
 
 ## Configuration sections
 
@@ -37,11 +36,10 @@ Additionally, you must include at least one of:
 
 ### App components
 
-| Property | Type   | Description                                      | Required                  |
-| -------- | ------ | ------------------------------------------------ | ------------------------- |
-| `post`   | object | Custom post/web view configuration               | One of post/server/blocks |
-| `server` | object | Node.js server configuration                     | One of post/server/blocks |
-| `blocks` | object | Deprecated configuration for migrating Blocks apps | One of post/server/blocks |
+| Property | Type   | Description                        | Required           |
+| -------- | ------ | ---------------------------------- | ------------------ |
+| `post`   | object | Custom post/web view configuration | One of post/server |
+| `server` | object | Node.js server configuration       | One of post/server |
 
 ### Permissions & capabilities
 
@@ -135,7 +133,6 @@ Control what your app can access:
       "domains": ["example.com", "api.github.com"]
     },
     "media": true,
-    "journeys": true,
     "payments": false,
     "realtime": false,
     "redis": true,
@@ -162,7 +159,6 @@ Control what your app can access:
 **Other permissions:**
 
 - `media` (boolean): Enable media uploads (default: `false`)
-- `journeys` (boolean): Enable [Devvit Journeys](../analytics/devvit-journeys.md) telemetry (default: `false`)
 - `payments` (boolean): Enable the payments plugin (default: `false`)
 - `realtime` (boolean): Enable realtime messaging (default: `false`)
 - `redis` (boolean): Enable Redis storage (default: `false`)
@@ -405,7 +401,7 @@ The Devvit CLI validates `devvit.json` against the JSON Schema before playtest, 
 
 - **JSON Syntax:** Adding comments or trailing commas (unsupported by JSON)
 - **Required Properties:** Missing the required `name` property
-- **App Components:** Missing at least one of `post` or `server` (or deprecated `blocks` migration configuration)
+- **App Components:** Missing at least one of `post` or `server`
 - **Dependencies:** Missing `server` when `triggers` is specified
 - **File References:** Missing files referenced in `devvit.json`
 - **Permissions:** Missing required permissions for used features

--- a/docs/capabilities/server/launch_screen_and_entry_points/launch_screen_customization.md
+++ b/docs/capabilities/server/launch_screen_and_entry_points/launch_screen_customization.md
@@ -28,9 +28,9 @@ import { requestExpandedMode } from '@devvit/web/client';
 document.addEventListener('DOMContentLoaded', () => {
   const playButton = document.getElementById('play-button');
 
-  playButton.addEventListener('click', async (event) => {
+  playButton.addEventListener('click', (event) => {
     try {
-      await requestExpandedMode(event, 'game');
+      requestExpandedMode(event, 'game');
     } catch (error) {
       console.error('Failed to enter expanded mode:', error);
     }
@@ -47,13 +47,13 @@ Requests expanded mode for the web view. This displays the web view in a larger 
 ```tsx
 import { requestExpandedMode } from '@devvit/web/client';
 
-// Must be called from a trusted event (click, touch, etc.)
-await requestExpandedMode(event, 'game');
+// Must be called synchronously from a trusted click event.
+requestExpandedMode(event, 'game');
 ```
 
 **Parameters**
 
-- `event` (PointerEvent): The gesture that triggered the request, must be a trusted event
+- `event` (MouseEvent): The trusted `click` event that triggered the request
 - `entry` (string): The destination URI name (e.g., `splash` or `game`). Entry names are the `devvit.json post.entrypoints` keys
 
 ### getWebViewMode()
@@ -72,23 +72,21 @@ if (currentMode === 'expanded') {
 }
 ```
 
-### Mode Change Events
+### Returning to inline mode
 
-Listen for mode changes to update your UI.
+The legacy `addWebViewModeListener()` and `removeWebViewModeListener()` APIs are deprecated. Listen for the window `focus` event to detect when an expanded web view returns to inline mode, then read the current mode again.
 
 ```tsx
-import { addWebViewModeListener, removeWebViewModeListener } from '@devvit/web/client';
+import { getWebViewMode } from '@devvit/web/client';
 
 function useWebViewMode() {
   const [mode, setMode] = useState(getWebViewMode());
 
   useEffect(() => {
-    const handleModeChange = (newMode: 'inline' | 'expanded') => {
-      setMode(newMode);
-    };
+    const handleFocus = () => setMode(getWebViewMode());
 
-    addWebViewModeListener(handleModeChange);
-    return () => removeWebViewModeListener(handleModeChange);
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
   }, []);
 
   return mode;
@@ -103,8 +101,6 @@ import {
   getWebViewMode,
   requestExpandedMode,
   exitExpandedMode,
-  addWebViewModeListener,
-  removeWebViewModeListener,
 } from '@devvit/web/client';
 
 export function GameApp() {
@@ -112,33 +108,35 @@ export function GameApp() {
   const [gameStarted, setGameStarted] = useState(false);
 
   useEffect(() => {
-    const handleModeChange = (newMode: 'inline' | 'expanded') => {
-      setMode(newMode);
+    const handleFocus = () => {
+      const nextMode = getWebViewMode();
+      setMode(nextMode);
 
-      // Pause game when exiting expanded mode
-      if (newMode === 'inline' && gameStarted) {
+      // Pause game when returning to inline mode.
+      if (nextMode === 'inline' && gameStarted) {
         pauseGame();
       }
     };
 
-    addWebViewModeListener(handleModeChange);
-    return () => removeWebViewModeListener(handleModeChange);
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
   }, [gameStarted]);
 
-  const handlePlayClick = async (event: React.MouseEvent) => {
+  const handlePlayClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     try {
-      await requestExpandedMode(event.nativeEvent, 'game');
+      requestExpandedMode(event.nativeEvent, 'game');
+      setMode('expanded');
       setGameStarted(true);
     } catch (error) {
       console.error('Could not enter expanded mode:', error);
-      // Fallback: start game inline
+      // Fallback: start game inline.
       setGameStarted(true);
     }
   };
 
-  const handleExitClick = async (event: React.MouseEvent) => {
+  const handleExitClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     try {
-      await exitExpandedMode(event.nativeEvent);
+      exitExpandedMode(event.nativeEvent);
     } catch (error) {
       console.error('Could not exit expanded mode:', error);
     }

--- a/docs/capabilities/server/redis.mdx
+++ b/docs/capabilities/server/redis.mdx
@@ -12,14 +12,14 @@ You can add a database to your app to store and retrieve data. The Redis plugin 
 - [Hashes](#hash) for managing a collection of key-value pairs
 - [Bitfields](#bitfield) for efficient operation on sequences of bits
 
-Redis is a good model for most community games, mod tools, settings, leaderboards, and user state.  If your app needs cross-community data, like a global leaderboard or aggregated analytics, design for that explicitly. Instead of assuming every installation can access the same Redis keys, use a shared service exposed through [HTTP Fetch](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/http-fetch.mdx) to manage and serve cross-community data.
+Redis is a good model for most community games, mod tools, settings, leaderboards, and user state.  If your app needs cross-community data, like a global leaderboard or aggregated analytics, design for that explicitly. Instead of assuming every installation can access the same Redis keys, use a shared service exposed through [HTTP Fetch](./http-fetch.mdx) to manage and serve cross-community data.
 
 ## Data storage
 
 Each installation of an app is uniquely name-spaced, which means Redis data is siloed by subreddit. Keep in mind that there won’t be a single source of truth for all installations of your app, since each app installation can only access the data that it has stored in the Redis database.
 
 :::note    
-If your app stores user content from Reddit, make sure you remove it from your app when that content is deleted from Reddit. Devvit provides post and comment delete events through triggers to help with this. See [Enable and respect user deletions](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/devvit_rules.md#enable-and-respect-user-deletions) in the Devvit Rules.  
+If your app stores user content from Reddit, make sure you remove it from your app when that content is deleted from Reddit. Devvit provides post and comment delete events through triggers to help with this. See [Enable and respect user deletions](../../devvit_rules.md#enable-and-respect-user-deletions) in the Devvit Rules.
 :::
 
 ## Key design
@@ -60,7 +60,7 @@ Use these patterns when you need set-like or queue-like behavior.
 | Dense flags or compact counters | Use bitfield when you need bitmap-style storage for many small values. |
 | Temporary data | Use expire for short-lived keys, or remove old sorted set entries by score. |
 
-For command-specific behavior and limits, see the [supported Redis commands](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#supported-redis-commands).
+For command-specific behavior and limits, see the [supported Redis commands](#supported-redis-commands).
 
 ## Storage values
 
@@ -75,7 +75,7 @@ await redisCompressed.set('cache:heavy_payload', JSON.stringify(payload));
 
 The compressed client compresses supported writes when compression saves space, and decompresses those values on supported reads.
 
-:::tip: Do not mix `redis` and `redisCompressed` on the same key. Data written by `redisCompressed` should be read with `redisCompressed`. To migrate existing data, read the old values with the standard client and write them back with the compressed client. For a complete migration example, see [Compression](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#compression-experimental).  
+:::tip: Do not mix `redis` and `redisCompressed` on the same key. Data written by `redisCompressed` should be read with `redisCompressed`. To migrate existing data, read the old values with the standard client and write them back with the compressed client. For a complete migration example, see [Compression](#compression-experimental).
 :::
 
 ## Shared state
@@ -93,18 +93,28 @@ Good candidates for transactions include:
 
 You usually do not need a transaction for single-command atomic operations, like `incrBy`, `hIncrBy`, or `zIncrBy`, unless the update depends on a separate read or validation step.
 
-```
- async function deductBalance(userId: string, cost: number): Promise<boolean> {
-const key = `user:${userId}:balance`;const txn = await redis.watch(key);
-const currentRaw = await txn.get(key);const current = currentRaw ? Number.parseInt(currentRaw, 10) : 0;
-if (current < cost) {	await txn.unwatch();	return false; }
-await txn.multi();await txn.set(key, String(current - cost));
-const result = await txn.exec();return result !== null;}
+```ts
+async function deductBalance(userId: string, cost: number): Promise<boolean> {
+  const key = `user:${userId}:balance`;
+  const txn = await redis.watch(key);
+  const currentRaw = await txn.get(key);
+  const current = currentRaw ? Number.parseInt(currentRaw, 10) : 0;
+
+  if (current < cost) {
+    await txn.unwatch();
+    return false;
+  }
+
+  await txn.multi();
+  await txn.set(key, String(current - cost));
+  const result = await txn.exec();
+  return result !== null;
+}
 ```
 
 Transactions are limited to 30 concurrent transaction blocks per installation, and transaction execution has a 5-second timeout. Always call unwatch() or discard() when your code exits early before exec().
 
-For more details, see [Transactions](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#transactions).
+For more details, see [Transactions](#transactions).
 
 ## Storage limit failures
 
@@ -157,8 +167,8 @@ This pattern works well for:
 
 The Redis reference includes a full scheduled migration example. The Scheduler reference covers recurring and one-off jobs, including platform limits for runJob().
 
-* [Redis migration example](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#migration-example)  
-* [Scheduler](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/scheduler.mdx)
+* [Redis migration example](#migration-example)
+* [Scheduler](./scheduler.mdx)
 
 ## Platform limits
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -56,13 +56,13 @@ Additional improvements in this release include:
 - **Increased app slug length**. App slugs can now be up to 20 characters. 
 
 
-## Relese 0.13.5: Improved Tracing
+## Release 0.13.5: Improved Tracing
 **Release Date: June 23, 2026**
 
 In this release, we've improved trace propagation between web view and plugin calls. Apps running v0.13.5+ will have more complete traces, providing better observability and simplifying debugging and support.
 
 
-## Relese 0.13.4: Updated Redis Docs
+## Release 0.13.4: Updated Redis Docs
 **Release Date: June 15, 2026**
 
 In this release, we’ve updated our [Redis](./capabilities/server/redis.mdx) documentation based on your feedback, adding clearer guidance around key design, data structures, shared states, and scheduled maintenance.

--- a/docs/guides/tools/devvit_cli.mdx
+++ b/docs/guides/tools/devvit_cli.mdx
@@ -170,11 +170,11 @@ $ npx devvit logs <subreddit> [app-name] [-d <value>] [-j] [-s <value>] [--verbo
 
   The subreddit name. The "r/" prefix is optional.
 
+#### Optional arguments
+
 - `app-name`
 
-  The app name (defaults to working directory app).
-
-#### Optional arguments
+  The app name. Defaults to the app in the working directory.
 
 - `-d <value>, --dateformat <value>`
 
@@ -214,34 +214,40 @@ $ npx devvit logs mySubreddit my-app --since 15s
 $ npx devvit logs mySubreddit my-app --verbose
 ```
 
-### devvit new
+### devvit init
 
-Create a new app.
+Initialize a new app. `devvit new` is retained as an alias.
+
+Without an initialization code, this command opens the app-creation flow in your browser. Outside a Devvit project, the generated project is placed in a directory named after the new app. Inside an uninitialized Devvit project, the command initializes that directory. Use `--force` only to replace an app that has already been initialized.
 
 #### Usage
 
 ```bash
-$ npx devvit new [directory-name] [--here]
+$ npx devvit init [code] [--template <name>] [--force]
 ```
 
 #### Optional arguments
 
-- `directory-name`
+- `code`
 
-  Directory name for your new app project. This creates a new directory for your app code. If no name is entered, you will be prompted to choose one.
+  Initialization code supplied by Reddit. If omitted, the CLI opens the browser flow to create the app and obtain a code.
 
-- `--here`
+- `--template <name>`
 
-  Generate the project here and not in a subdirectory.
+  Select a project template without opening the template-selection prompt.
+
+- `--force`
+
+  Initialize a new app even when the current directory is already a Devvit app.
 
 #### Examples
 
 ```bash
-$ npx devvit new
+$ npx devvit init
 
-$ npx devvit new tic-tac-toe
+$ npx devvit init <code>
 
-$ npx devvit new --here
+$ npx devvit init --template <template-name>
 ```
 
 ### devvit playtest
@@ -251,13 +257,22 @@ Installs your app to your test subreddit and starts a playtest session. A new ve
 #### Usage
 
 ```bash
-$ npx devvit playtest
+$ npx devvit playtest [subreddit] [--debounce <milliseconds>] [logging options]
 ```
 
-#### Optional argument
+#### Optional arguments
 
-- subreddit
+- `subreddit`
+
   Name of a test subreddit with less than 200 subscribers that you moderate. The "r/" prefix is optional.
+
+- `--debounce <milliseconds>`
+
+  Debounce file-change handling by the specified number of milliseconds.
+
+- Logging options
+
+  `playtest` accepts the same public log-formatting and filtering flags as [`devvit logs`](#devvit-logs), including `--dateformat`, `--json`, `--log-runtime`, `--show-timestamps`, `--since`, and `--verbose`.
 
 If no subreddit is specified, the command will use the first available option from:
 
@@ -309,9 +324,11 @@ $ npx devvit uninstall <subreddit> [app-name]
 
   Name of the subreddit. The "r/" prefix is optional. Requires moderator permissions in the subreddit.
 
+#### Optional argument
+
 - `app-name`
 
-  Name of the app (defaults to the working directory app).
+  Name of the app. Defaults to the app in the working directory.
 
 #### Examples
 
@@ -333,6 +350,42 @@ Update @devvit project dependencies to the currently installed CLI's version
 $ npx devvit update app
 ```
 
+### devvit publish
+
+Create a new app version, upload the app and its source for review, and submit a publish request.
+
+#### Usage
+
+```bash
+$ npx devvit publish [--bump major|minor|patch | --version <version>] [--public] [--withdraw] [--copy-paste] [--verbose]
+```
+
+#### Optional arguments
+
+- `--bump <option>`
+
+  Type of version bump: `major`, `minor`, or `patch`. Patch is the default. Cannot be combined with `--version`.
+
+- `--version <version>`
+
+  Explicit non-prerelease version number, such as `1.0.1`. Cannot be combined with `--bump`.
+
+- `--public`
+
+  Submit the app for public review rather than the default unlisted review.
+
+- `--withdraw`
+
+  Withdraw the app's most recent pending publish request. Cannot be combined with `--public`.
+
+- `--copy-paste`
+
+  Copy and paste the authentication code instead of opening a local browser callback.
+
+- `--verbose`
+
+  Enable verbose logging.
+
 ### devvit upload
 
 Upload an app to the App directory. By default the app is private and visible only to you.
@@ -340,18 +393,26 @@ Upload an app to the App directory. By default the app is private and visible on
 #### Usage
 
 ```bash
-$ npx devvit upload [--bump major|minor|patch|prerelease] [--copyPaste]
+$ npx devvit upload [--bump major|minor|patch|prerelease | --version <version>] [--copy-paste] [--verbose]
 ```
 
 #### Optional arguments
 
 - `--bump <option>`
 
-  Type of version bump (major|minor|patch|prerelease)
+  Type of version bump: `major`, `minor`, `patch`, or `prerelease`. Cannot be combined with `--version`.
 
-- `--copyPaste`
+- `--version <version>`
 
-  Copy-paste the auth code instead of opening a browser
+  Explicit version number, such as `1.0.1`. Cannot be combined with `--bump`.
+
+- `--copy-paste`
+
+  Copy and paste the authentication code instead of opening a local browser callback.
+
+- `--verbose`
+
+  Enable verbose logging.
 
 ### devvit version
 
@@ -365,12 +426,30 @@ $ npx devvit version
 
 ### devvit view
 
-Shows you the latest version of your app and some data about uploads. Includes an optional --json flag to get information in JSON format.
+Show details about an app version. The app defaults to the project in the working directory, and the version defaults to `latest`.
 
-#### Usage​
+#### Usage
 
 ```bash
-$ npx devvit view [APPSLUG[@VERSION]] [--json] [version]
+$ npx devvit view [app-name[@version]] [version] [--json]
+```
+
+The optional literal `version` subcommand prints only the resolved version number. To select an app version, append it to the app name with `@`.
+
+#### Examples
+
+```bash
+$ npx devvit view
+
+$ npx devvit view my-app
+
+$ npx devvit view my-app@1.2.3
+
+$ npx devvit view @1.2.3
+
+$ npx devvit view my-app@1.2.3 version
+
+$ npx devvit view --json
 ```
 
 ### devvit whoami

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,7 +4,12 @@ import { themes as prismThemes } from "prism-react-renderer";
 
 const baseUrl = process.env.DOCUSAURUS_BASE_URL ?? "/docs/";
 
-const LATEST_DEVVIT_VERSION = '0.13'; // update-versioned-docs.mjs sets this automatically
+// Docusaurus stores published documentation versions newest first.
+const [LATEST_DEVVIT_VERSION] = require("./versions.json") as string[];
+
+if (!LATEST_DEVVIT_VERSION) {
+  throw new Error("versions.json must contain at least one published documentation version");
+}
 
 const config: Config = {
   future: {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -210,7 +210,6 @@ const sidebars: SidebarsConfig = {
        "capabilities/client/navigation",
         "capabilities/client/toasts",
         "capabilities/client/menu-actions",
-        "capabilities/server/launch_screen_and_entry_points/view_modes_entry_points",
         {
           type: "category",
           label: "Launch Screen",

--- a/versioned_docs/version-0.13/capabilities/devvit-web/devvit_web_configuration.md
+++ b/versioned_docs/version-0.13/capabilities/devvit-web/devvit_web_configuration.md
@@ -1,6 +1,6 @@
 # Configure your app
 
-The devvit.json file serves as your app's configuration file. Use it to specify entry points, configure features like [event triggers](../server/triggers) and [scheduled actions](../server/scheduler.mdx), and enable app functionality such as [image uploads](../server/media-uploads.mdx). This page covers all available devvit.json configuration options. A complete devvit.json example file is provided [here](#complete-example).
+The `devvit.json` file serves as your app's configuration file. Use it to specify entry points, configure features like [event triggers](../server/triggers) and [scheduled actions](../server/scheduler.mdx), and enable app functionality such as [image uploads](../server/media-uploads.mdx). This page summarizes the schema-supported configuration options; the published JSON Schema remains authoritative. A representative `devvit.json` example is provided [here](#complete-example).
 
 ## devvit.json
 
@@ -18,12 +18,13 @@ All configuration files should include a `$schema` property which many IDEs will
 
 Your `devvit.json` must include:
 
-- **`name`** (required): App account name and Community URL slug. Must be 3-16 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens.
+- **`name`** (required): App account name and Community URL slug. Must be 3-20 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens.
 
 Additionally, you must include at least one of:
 
 - **`post`**: For web view apps
 - **`server`**: For Node.js server apps
+- **`blocks`**: Deprecated migration configuration for legacy Blocks apps
 
 ## Configuration sections
 
@@ -31,15 +32,16 @@ Additionally, you must include at least one of:
 
 | Property  | Type   | Description                                                               | Required         |
 | --------- | ------ | ------------------------------------------------------------------------- | ---------------- |
-| `name`    | string | App account name and Community URL slug (3-16 chars, `^[a-z][a-z0-9-]*$`) | Yes              |
+| `name`    | string | App account name and Community URL slug (3-20 chars, `^[a-z][a-z0-9-]*$`) | Yes              |
 | `$schema` | string | Schema version for IDE support                                            | No (recommended) |
 
 ### App components
 
-| Property | Type   | Description                        | Required           |
-| -------- | ------ | ---------------------------------- | ------------------ |
-| `post`   | object | Custom post/web view configuration | One of post/server |
-| `server` | object | Node.js server configuration       | One of post/server |
+| Property | Type   | Description                                      | Required                  |
+| -------- | ------ | ------------------------------------------------ | ------------------------- |
+| `post`   | object | Custom post/web view configuration               | One of post/server/blocks |
+| `server` | object | Node.js server configuration                     | One of post/server/blocks |
+| `blocks` | object | Deprecated configuration for migrating Blocks apps | One of post/server/blocks |
 
 ### Permissions & capabilities
 
@@ -58,17 +60,19 @@ Additionally, you must include at least one of:
 
 ### UI & interaction
 
-| Property | Type   | Description                               | Required |
-| -------- | ------ | ----------------------------------------- | -------- |
-| `menu`   | object | Menu items in posts, comments, subreddits | No       |
-| `forms`  | object | Form submission endpoints                 | No       |
+| Property   | Type   | Description                                      | Required |
+| ---------- | ------ | ------------------------------------------------ | -------- |
+| `menu`     | object | Menu items in posts, comments, and subreddits    | No       |
+| `forms`    | object | Form submission endpoints                        | No       |
+| `settings` | object | Global and per-subreddit app settings definitions | No       |
 
 ### Development
 
-| Property  | Type   | Description                                         | Required |
-| --------- | ------ | --------------------------------------------------- | -------- |
-| `dev`     | object | Development configuration                           | No       |
-| `scripts` | object | Build commands run by the Devvit CLI (optional)     | No       |
+| Property        | Type   | Description                                             | Required |
+| --------------- | ------ | ------------------------------------------------------- | -------- |
+| `dev`           | object | Development configuration                               | No       |
+| `scripts`       | object | Build commands run by the Devvit CLI                     | No       |
+| `sourceIgnores` | array  | Source files excluded from packages submitted for review | No       |
 
 ## Detailed configuration
 
@@ -96,7 +100,7 @@ Configure web views for custom post types:
 - `entrypoints` (object): Map of named entrypoints for post rendering
   - Must include a `"default"` entrypoint
   - `entry` (string): HTML file path or `/api/` endpoint
-  - `height` (enum): `"regular"` or `"tall"` (default: `"regular"`)
+  - `height` (enum): `"regular"` or `"tall"` (default: `"tall"`)
 
 ### Server configuration
 
@@ -105,14 +109,17 @@ Configure Node.js server functionality:
 ```json
 {
   "server": {
-    "entry": "src/server/index.js"
+    "dir": "dist/server",
+    "entry": "index.js"
   }
 }
 ```
 
 **Properties:**
 
-- `entry` (string): Server bundle filename (default: `"src/server/index.js"`)
+- `dir` (string): Server bundle directory relative to the project root (default: `"dist/server"`)
+- `entry` (string): Server bundle filename within `server.dir` (default: `"index.js"`)
+- `externalEndpoints` (object): Named `/external/` routes available to approved outside callers. See [External Endpoints](../server/external-endpoints.mdx).
 
 Server bundles must be compiled to CommonJS (`cjs`). ES module output is not supported by the Devvit Web runtime.
 
@@ -128,9 +135,11 @@ Control what your app can access:
       "domains": ["example.com", "api.github.com"]
     },
     "media": true,
+    "journeys": true,
     "payments": false,
     "realtime": false,
     "redis": true,
+    "chromeless": false,
     "reddit": {
       "enable": true,
       "asUser": ["SUBMIT_POST", "SUBMIT_COMMENT"]
@@ -153,9 +162,12 @@ Control what your app can access:
 **Other permissions:**
 
 - `media` (boolean): Enable media uploads (default: `false`)
-- `payments` (boolean): Enable payments plugin (default: `false`)
+- `journeys` (boolean): Enable [Devvit Journeys](../analytics/devvit-journeys.md) telemetry (default: `false`)
+- `payments` (boolean): Enable the payments plugin (default: `false`)
 - `realtime` (boolean): Enable realtime messaging (default: `false`)
 - `redis` (boolean): Enable Redis storage (default: `false`)
+- `chromeless` (boolean): Allow supported custom posts to render without standard post chrome when highlighted (default: `false`)
+- `blob` (boolean): Reserved for the experimental Blob Storage capability and not yet publicly available. Follow the current [Blob Storage](../server/blob-storage.mdx) setup instructions rather than enabling this field unless directed by Reddit.
 
 ### Triggers configuration
 
@@ -176,6 +188,7 @@ Handle Reddit events:
 - `onAppInstall`, `onAppUpgrade`
 - `onPostCreate`, `onPostDelete`, `onPostSubmit`, `onPostUpdate`, `onPostReport`, `onPostFlairUpdate`, `onPostNsfwUpdate`, `onPostSpoilerUpdate`
 - `onCommentCreate`, `onCommentDelete`, `onCommentSubmit`, `onCommentUpdate`, `onCommentReport`
+- `onMentionInCommentCreate` (limited access; see [Global Triggers](../server/global-triggers.mdx))
 - `onModAction`, `onModMail`
 - `onAutomoderatorFilterPost`, `onAutomoderatorFilterComment`
 
@@ -264,6 +277,66 @@ Map form identifiers to submission endpoints:
 }
 ```
 
+### Static asset configuration
+
+Configure a directory of static assets that is available to both the app client and server:
+
+```json
+{
+  "media": {
+    "dir": "assets"
+  }
+}
+```
+
+- `dir` (string): Static asset directory relative to the project root (default: `"assets"`)
+
+This top-level `media` object is separate from `permissions.media`, which enables runtime media uploads.
+
+### Settings configuration
+
+Define settings that apply globally or can be configured separately for each subreddit installation:
+
+```json
+{
+  "settings": {
+    "global": {
+      "featureEnabled": {
+        "type": "boolean",
+        "label": "Enable feature",
+        "defaultValue": true
+      }
+    },
+    "subreddit": {
+      "welcomeMessage": {
+        "type": "paragraph",
+        "label": "Welcome message"
+      }
+    }
+  }
+}
+```
+
+At least one of `global` or `subreddit` is required. Supported setting types include strings, paragraphs, numbers, booleans, selects, and multi-selects. See [Settings and Secrets](../server/settings-and-secrets.mdx) for validation and access patterns.
+
+### Payments configuration
+
+The top-level `payments` object declares products and the internal endpoints used to fulfill or refund orders. It is separate from `permissions.payments`, which enables the payments plugin.
+
+```json
+{
+  "payments": {
+    "productsFile": "products.json",
+    "endpoints": {
+      "fulfillOrder": "/internal/payments/fulfill-order",
+      "refundOrder": "/internal/payments/refund-order"
+    }
+  }
+}
+```
+
+Provide either inline `products` or a `productsFile`, and always configure `endpoints.fulfillOrder`. See [Add Payments](../../earn-money/payments/payments_add.mdx) for the complete product schema and implementation steps.
+
 ### Marketing assets
 
 Configure app presentation:
@@ -298,6 +371,18 @@ Configure build commands run by the Devvit CLI. These commands run relative to t
 - `dev` (string): Command run by `devvit playtest` to build or watch your client/server artifacts
 - `build` (string): Command run by `devvit upload` to build your client/server artifacts
 
+### Source packaging exclusions
+
+Use `sourceIgnores` to exclude files from the source archive submitted during `devvit publish`. Patterns use `.gitignore` syntax and are evaluated after the root `.gitignore` file.
+
+```json
+{
+  "sourceIgnores": ["coverage/", "*.log", "fixtures/private/"]
+}
+```
+
+Patterns are relative to the project root. Some paths, including `node_modules/`, `.env`, and `.git/`, are always excluded.
+
 ### Development configuration
 
 Configure development settings:
@@ -316,11 +401,11 @@ Configure development settings:
 
 ## Validation rules
 
-The `devvit.json` configuration is validated against the JSON Schema at build time. Many IDEs will also underline errors as you write. Common validation errors include:
+The Devvit CLI validates `devvit.json` against the JSON Schema before playtest, upload, and publish operations. Many IDEs will also underline errors as you write. Common validation errors include:
 
 - **JSON Syntax:** Adding comments or trailing commas (unsupported by JSON)
 - **Required Properties:** Missing the required `name` property
-- **App Components:** Missing at least one of `post` or `server`
+- **App Components:** Missing at least one of `post` or `server` (or deprecated `blocks` migration configuration)
 - **Dependencies:** Missing `server` when `triggers` is specified
 - **File References:** Missing files referenced in `devvit.json`
 - **Permissions:** Missing required permissions for used features
@@ -333,7 +418,7 @@ The `devvit.json` configuration is validated against the JSON Schema at build ti
 3. **Set appropriate menu scopes.** Consider whether features should be available to all users or just moderators.
 4. **Validate endpoints.** Ensure all internal endpoints start with `/internal/`.
 5. **Use meaningful names.** Choose descriptive names for entrypoints, tasks, and forms.
-6. **Test configurations.** Validate your config with `devvit build` before deployment.
+6. **Test configurations.** Use `devvit playtest` during development; `devvit playtest`, `devvit upload`, and `devvit publish` validate the configuration before packaging.
 
 ## Environment variables
 
@@ -356,7 +441,8 @@ The `devvit.json` configuration is validated against the JSON Schema at build ti
     }
   },
   "server": {
-    "entry": "src/server/index.js"
+    "dir": "dist/server",
+    "entry": "index.js"
   },
   "permissions": {
     "http": {

--- a/versioned_docs/version-0.13/capabilities/devvit-web/devvit_web_configuration.md
+++ b/versioned_docs/version-0.13/capabilities/devvit-web/devvit_web_configuration.md
@@ -1,4 +1,4 @@
-# Configure your app
+﻿# Configure your app
 
 The `devvit.json` file serves as your app's configuration file. Use it to specify entry points, configure features like [event triggers](../server/triggers) and [scheduled actions](../server/scheduler.mdx), and enable app functionality such as [image uploads](../server/media-uploads.mdx). This page summarizes the schema-supported configuration options; the published JSON Schema remains authoritative. A representative `devvit.json` example is provided [here](#complete-example).
 
@@ -24,7 +24,6 @@ Additionally, you must include at least one of:
 
 - **`post`**: For web view apps
 - **`server`**: For Node.js server apps
-- **`blocks`**: Deprecated migration configuration for legacy Blocks apps
 
 ## Configuration sections
 
@@ -37,11 +36,10 @@ Additionally, you must include at least one of:
 
 ### App components
 
-| Property | Type   | Description                                      | Required                  |
-| -------- | ------ | ------------------------------------------------ | ------------------------- |
-| `post`   | object | Custom post/web view configuration               | One of post/server/blocks |
-| `server` | object | Node.js server configuration                     | One of post/server/blocks |
-| `blocks` | object | Deprecated configuration for migrating Blocks apps | One of post/server/blocks |
+| Property | Type   | Description                        | Required           |
+| -------- | ------ | ---------------------------------- | ------------------ |
+| `post`   | object | Custom post/web view configuration | One of post/server |
+| `server` | object | Node.js server configuration       | One of post/server |
 
 ### Permissions & capabilities
 
@@ -135,7 +133,6 @@ Control what your app can access:
       "domains": ["example.com", "api.github.com"]
     },
     "media": true,
-    "journeys": true,
     "payments": false,
     "realtime": false,
     "redis": true,
@@ -162,7 +159,6 @@ Control what your app can access:
 **Other permissions:**
 
 - `media` (boolean): Enable media uploads (default: `false`)
-- `journeys` (boolean): Enable [Devvit Journeys](../analytics/devvit-journeys.md) telemetry (default: `false`)
 - `payments` (boolean): Enable the payments plugin (default: `false`)
 - `realtime` (boolean): Enable realtime messaging (default: `false`)
 - `redis` (boolean): Enable Redis storage (default: `false`)
@@ -405,7 +401,7 @@ The Devvit CLI validates `devvit.json` against the JSON Schema before playtest, 
 
 - **JSON Syntax:** Adding comments or trailing commas (unsupported by JSON)
 - **Required Properties:** Missing the required `name` property
-- **App Components:** Missing at least one of `post` or `server` (or deprecated `blocks` migration configuration)
+- **App Components:** Missing at least one of `post` or `server`
 - **Dependencies:** Missing `server` when `triggers` is specified
 - **File References:** Missing files referenced in `devvit.json`
 - **Permissions:** Missing required permissions for used features

--- a/versioned_docs/version-0.13/capabilities/server/launch_screen_and_entry_points/launch_screen_customization.md
+++ b/versioned_docs/version-0.13/capabilities/server/launch_screen_and_entry_points/launch_screen_customization.md
@@ -28,9 +28,9 @@ import { requestExpandedMode } from '@devvit/web/client';
 document.addEventListener('DOMContentLoaded', () => {
   const playButton = document.getElementById('play-button');
 
-  playButton.addEventListener('click', async (event) => {
+  playButton.addEventListener('click', (event) => {
     try {
-      await requestExpandedMode(event, 'game');
+      requestExpandedMode(event, 'game');
     } catch (error) {
       console.error('Failed to enter expanded mode:', error);
     }
@@ -47,13 +47,13 @@ Requests expanded mode for the web view. This displays the web view in a larger 
 ```tsx
 import { requestExpandedMode } from '@devvit/web/client';
 
-// Must be called from a trusted event (click, touch, etc.)
-await requestExpandedMode(event, 'game');
+// Must be called synchronously from a trusted click event.
+requestExpandedMode(event, 'game');
 ```
 
 **Parameters**
 
-- `event` (PointerEvent): The gesture that triggered the request, must be a trusted event
+- `event` (MouseEvent): The trusted `click` event that triggered the request
 - `entry` (string): The destination URI name (e.g., `splash` or `game`). Entry names are the `devvit.json post.entrypoints` keys
 
 ### getWebViewMode()
@@ -72,23 +72,21 @@ if (currentMode === 'expanded') {
 }
 ```
 
-### Mode Change Events
+### Returning to inline mode
 
-Listen for mode changes to update your UI.
+The legacy `addWebViewModeListener()` and `removeWebViewModeListener()` APIs are deprecated. Listen for the window `focus` event to detect when an expanded web view returns to inline mode, then read the current mode again.
 
 ```tsx
-import { addWebViewModeListener, removeWebViewModeListener } from '@devvit/web/client';
+import { getWebViewMode } from '@devvit/web/client';
 
 function useWebViewMode() {
   const [mode, setMode] = useState(getWebViewMode());
 
   useEffect(() => {
-    const handleModeChange = (newMode: 'inline' | 'expanded') => {
-      setMode(newMode);
-    };
+    const handleFocus = () => setMode(getWebViewMode());
 
-    addWebViewModeListener(handleModeChange);
-    return () => removeWebViewModeListener(handleModeChange);
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
   }, []);
 
   return mode;
@@ -103,8 +101,6 @@ import {
   getWebViewMode,
   requestExpandedMode,
   exitExpandedMode,
-  addWebViewModeListener,
-  removeWebViewModeListener,
 } from '@devvit/web/client';
 
 export function GameApp() {
@@ -112,33 +108,35 @@ export function GameApp() {
   const [gameStarted, setGameStarted] = useState(false);
 
   useEffect(() => {
-    const handleModeChange = (newMode: 'inline' | 'expanded') => {
-      setMode(newMode);
+    const handleFocus = () => {
+      const nextMode = getWebViewMode();
+      setMode(nextMode);
 
-      // Pause game when exiting expanded mode
-      if (newMode === 'inline' && gameStarted) {
+      // Pause game when returning to inline mode.
+      if (nextMode === 'inline' && gameStarted) {
         pauseGame();
       }
     };
 
-    addWebViewModeListener(handleModeChange);
-    return () => removeWebViewModeListener(handleModeChange);
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
   }, [gameStarted]);
 
-  const handlePlayClick = async (event: React.MouseEvent) => {
+  const handlePlayClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     try {
-      await requestExpandedMode(event.nativeEvent, 'game');
+      requestExpandedMode(event.nativeEvent, 'game');
+      setMode('expanded');
       setGameStarted(true);
     } catch (error) {
       console.error('Could not enter expanded mode:', error);
-      // Fallback: start game inline
+      // Fallback: start game inline.
       setGameStarted(true);
     }
   };
 
-  const handleExitClick = async (event: React.MouseEvent) => {
+  const handleExitClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     try {
-      await exitExpandedMode(event.nativeEvent);
+      exitExpandedMode(event.nativeEvent);
     } catch (error) {
       console.error('Could not exit expanded mode:', error);
     }

--- a/versioned_docs/version-0.13/capabilities/server/redis.mdx
+++ b/versioned_docs/version-0.13/capabilities/server/redis.mdx
@@ -12,14 +12,14 @@ You can add a database to your app to store and retrieve data. The Redis plugin 
 - [Hashes](#hash) for managing a collection of key-value pairs
 - [Bitfields](#bitfield) for efficient operation on sequences of bits
 
-Redis is a good model for most community games, mod tools, settings, leaderboards, and user state.  If your app needs cross-community data, like a global leaderboard or aggregated analytics, design for that explicitly. Instead of assuming every installation can access the same Redis keys, use a shared service exposed through [HTTP Fetch](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/http-fetch.mdx) to manage and serve cross-community data.
+Redis is a good model for most community games, mod tools, settings, leaderboards, and user state.  If your app needs cross-community data, like a global leaderboard or aggregated analytics, design for that explicitly. Instead of assuming every installation can access the same Redis keys, use a shared service exposed through [HTTP Fetch](./http-fetch.mdx) to manage and serve cross-community data.
 
 ## Data storage
 
 Each installation of an app is uniquely name-spaced, which means Redis data is siloed by subreddit. Keep in mind that there won’t be a single source of truth for all installations of your app, since each app installation can only access the data that it has stored in the Redis database.
 
 :::note    
-If your app stores user content from Reddit, make sure you remove it from your app when that content is deleted from Reddit. Devvit provides post and comment delete events through triggers to help with this. See [Enable and respect user deletions](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/devvit_rules.md#enable-and-respect-user-deletions) in the Devvit Rules.  
+If your app stores user content from Reddit, make sure you remove it from your app when that content is deleted from Reddit. Devvit provides post and comment delete events through triggers to help with this. See [Enable and respect user deletions](../../devvit_rules.md#enable-and-respect-user-deletions) in the Devvit Rules.
 :::
 
 ## Key design
@@ -60,7 +60,7 @@ Use these patterns when you need set-like or queue-like behavior.
 | Dense flags or compact counters | Use bitfield when you need bitmap-style storage for many small values. |
 | Temporary data | Use expire for short-lived keys, or remove old sorted set entries by score. |
 
-For command-specific behavior and limits, see the [supported Redis commands](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#supported-redis-commands).
+For command-specific behavior and limits, see the [supported Redis commands](#supported-redis-commands).
 
 ## Storage values
 
@@ -75,7 +75,7 @@ await redisCompressed.set('cache:heavy_payload', JSON.stringify(payload));
 
 The compressed client compresses supported writes when compression saves space, and decompresses those values on supported reads.
 
-:::tip: Do not mix `redis` and `redisCompressed` on the same key. Data written by `redisCompressed` should be read with `redisCompressed`. To migrate existing data, read the old values with the standard client and write them back with the compressed client. For a complete migration example, see [Compression](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#compression-experimental).  
+:::tip: Do not mix `redis` and `redisCompressed` on the same key. Data written by `redisCompressed` should be read with `redisCompressed`. To migrate existing data, read the old values with the standard client and write them back with the compressed client. For a complete migration example, see [Compression](#compression-experimental).
 :::
 
 ## Shared state
@@ -93,18 +93,28 @@ Good candidates for transactions include:
 
 You usually do not need a transaction for single-command atomic operations, like `incrBy`, `hIncrBy`, or `zIncrBy`, unless the update depends on a separate read or validation step.
 
-```
- async function deductBalance(userId: string, cost: number): Promise<boolean> {
-const key = `user:${userId}:balance`;const txn = await redis.watch(key);
-const currentRaw = await txn.get(key);const current = currentRaw ? Number.parseInt(currentRaw, 10) : 0;
-if (current < cost) {	await txn.unwatch();	return false; }
-await txn.multi();await txn.set(key, String(current - cost));
-const result = await txn.exec();return result !== null;}
+```ts
+async function deductBalance(userId: string, cost: number): Promise<boolean> {
+  const key = `user:${userId}:balance`;
+  const txn = await redis.watch(key);
+  const currentRaw = await txn.get(key);
+  const current = currentRaw ? Number.parseInt(currentRaw, 10) : 0;
+
+  if (current < cost) {
+    await txn.unwatch();
+    return false;
+  }
+
+  await txn.multi();
+  await txn.set(key, String(current - cost));
+  const result = await txn.exec();
+  return result !== null;
+}
 ```
 
 Transactions are limited to 30 concurrent transaction blocks per installation, and transaction execution has a 5-second timeout. Always call unwatch() or discard() when your code exits early before exec().
 
-For more details, see [Transactions](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#transactions).
+For more details, see [Transactions](#transactions).
 
 ## Storage limit failures
 
@@ -157,8 +167,8 @@ This pattern works well for:
 
 The Redis reference includes a full scheduled migration example. The Scheduler reference covers recurring and one-off jobs, including platform limits for runJob().
 
-* [Redis migration example](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/redis.mdx#migration-example)  
-* [Scheduler](https://github.com/reddit/devvit-docs/blob/69f35f2254617e4a1347686235a560a78d94535b/versioned_docs/version-0.12/capabilities/server/scheduler.mdx)
+* [Redis migration example](#migration-example)
+* [Scheduler](./scheduler.mdx)
 
 ## Platform limits
 

--- a/versioned_docs/version-0.13/changelog.md
+++ b/versioned_docs/version-0.13/changelog.md
@@ -57,13 +57,13 @@ Additional improvements in this release include:
 - **Increased app slug length**. App slugs can now be up to 20 characters. 
 
 
-## Relese 0.13.5: Improved Tracing
+## Release 0.13.5: Improved Tracing
 **Release Date: June 23, 2026**
 
 In this release, we've improved trace propagation between web view and plugin calls. Apps running v0.13.5+ will have more complete traces, providing better observability and simplifying debugging and support.
 
 
-## Relese 0.13.4: Updated Redis Docs
+## Release 0.13.4: Updated Redis Docs
 **Release Date: June 15, 2026**
 
 In this release, we’ve updated our [Redis](./capabilities/server/redis.mdx) documentation based on your feedback, adding clearer guidance around key design, data structures, shared states, and scheduled maintenance.

--- a/versioned_docs/version-0.13/guides/tools/devvit_cli.mdx
+++ b/versioned_docs/version-0.13/guides/tools/devvit_cli.mdx
@@ -170,11 +170,11 @@ $ npx devvit logs <subreddit> [app-name] [-d <value>] [-j] [-s <value>] [--verbo
 
   The subreddit name. The "r/" prefix is optional.
 
+#### Optional arguments
+
 - `app-name`
 
-  The app name (defaults to working directory app).
-
-#### Optional arguments
+  The app name. Defaults to the app in the working directory.
 
 - `-d <value>, --dateformat <value>`
 
@@ -214,34 +214,40 @@ $ npx devvit logs mySubreddit my-app --since 15s
 $ npx devvit logs mySubreddit my-app --verbose
 ```
 
-### devvit new
+### devvit init
 
-Create a new app.
+Initialize a new app. `devvit new` is retained as an alias.
+
+Without an initialization code, this command opens the app-creation flow in your browser. Outside a Devvit project, the generated project is placed in a directory named after the new app. Inside an uninitialized Devvit project, the command initializes that directory. Use `--force` only to replace an app that has already been initialized.
 
 #### Usage
 
 ```bash
-$ npx devvit new [directory-name] [--here]
+$ npx devvit init [code] [--template <name>] [--force]
 ```
 
 #### Optional arguments
 
-- `directory-name`
+- `code`
 
-  Directory name for your new app project. This creates a new directory for your app code. If no name is entered, you will be prompted to choose one.
+  Initialization code supplied by Reddit. If omitted, the CLI opens the browser flow to create the app and obtain a code.
 
-- `--here`
+- `--template <name>`
 
-  Generate the project here and not in a subdirectory.
+  Select a project template without opening the template-selection prompt.
+
+- `--force`
+
+  Initialize a new app even when the current directory is already a Devvit app.
 
 #### Examples
 
 ```bash
-$ npx devvit new
+$ npx devvit init
 
-$ npx devvit new tic-tac-toe
+$ npx devvit init <code>
 
-$ npx devvit new --here
+$ npx devvit init --template <template-name>
 ```
 
 ### devvit playtest
@@ -251,13 +257,22 @@ Installs your app to your test subreddit and starts a playtest session. A new ve
 #### Usage
 
 ```bash
-$ npx devvit playtest
+$ npx devvit playtest [subreddit] [--debounce <milliseconds>] [logging options]
 ```
 
-#### Optional argument
+#### Optional arguments
 
-- subreddit
+- `subreddit`
+
   Name of a test subreddit with less than 200 subscribers that you moderate. The "r/" prefix is optional.
+
+- `--debounce <milliseconds>`
+
+  Debounce file-change handling by the specified number of milliseconds.
+
+- Logging options
+
+  `playtest` accepts the same public log-formatting and filtering flags as [`devvit logs`](#devvit-logs), including `--dateformat`, `--json`, `--log-runtime`, `--show-timestamps`, `--since`, and `--verbose`.
 
 If no subreddit is specified, the command will use the first available option from:
 
@@ -309,9 +324,11 @@ $ npx devvit uninstall <subreddit> [app-name]
 
   Name of the subreddit. The "r/" prefix is optional. Requires moderator permissions in the subreddit.
 
+#### Optional argument
+
 - `app-name`
 
-  Name of the app (defaults to the working directory app).
+  Name of the app. Defaults to the app in the working directory.
 
 #### Examples
 
@@ -333,6 +350,42 @@ Update @devvit project dependencies to the currently installed CLI's version
 $ npx devvit update app
 ```
 
+### devvit publish
+
+Create a new app version, upload the app and its source for review, and submit a publish request.
+
+#### Usage
+
+```bash
+$ npx devvit publish [--bump major|minor|patch | --version <version>] [--public] [--withdraw] [--copy-paste] [--verbose]
+```
+
+#### Optional arguments
+
+- `--bump <option>`
+
+  Type of version bump: `major`, `minor`, or `patch`. Patch is the default. Cannot be combined with `--version`.
+
+- `--version <version>`
+
+  Explicit non-prerelease version number, such as `1.0.1`. Cannot be combined with `--bump`.
+
+- `--public`
+
+  Submit the app for public review rather than the default unlisted review.
+
+- `--withdraw`
+
+  Withdraw the app's most recent pending publish request. Cannot be combined with `--public`.
+
+- `--copy-paste`
+
+  Copy and paste the authentication code instead of opening a local browser callback.
+
+- `--verbose`
+
+  Enable verbose logging.
+
 ### devvit upload
 
 Upload an app to the App directory. By default the app is private and visible only to you.
@@ -340,18 +393,26 @@ Upload an app to the App directory. By default the app is private and visible on
 #### Usage
 
 ```bash
-$ npx devvit upload [--bump major|minor|patch|prerelease] [--copyPaste]
+$ npx devvit upload [--bump major|minor|patch|prerelease | --version <version>] [--copy-paste] [--verbose]
 ```
 
 #### Optional arguments
 
 - `--bump <option>`
 
-  Type of version bump (major|minor|patch|prerelease)
+  Type of version bump: `major`, `minor`, `patch`, or `prerelease`. Cannot be combined with `--version`.
 
-- `--copyPaste`
+- `--version <version>`
 
-  Copy-paste the auth code instead of opening a browser
+  Explicit version number, such as `1.0.1`. Cannot be combined with `--bump`.
+
+- `--copy-paste`
+
+  Copy and paste the authentication code instead of opening a local browser callback.
+
+- `--verbose`
+
+  Enable verbose logging.
 
 ### devvit version
 
@@ -365,12 +426,30 @@ $ npx devvit version
 
 ### devvit view
 
-Shows you the latest version of your app and some data about uploads. Includes an optional --json flag to get information in JSON format.
+Show details about an app version. The app defaults to the project in the working directory, and the version defaults to `latest`.
 
-#### Usage​
+#### Usage
 
 ```bash
-$ npx devvit view [APPSLUG[@VERSION]] [--json] [version]
+$ npx devvit view [app-name[@version]] [version] [--json]
+```
+
+The optional literal `version` subcommand prints only the resolved version number. To select an app version, append it to the app name with `@`.
+
+#### Examples
+
+```bash
+$ npx devvit view
+
+$ npx devvit view my-app
+
+$ npx devvit view my-app@1.2.3
+
+$ npx devvit view @1.2.3
+
+$ npx devvit view my-app@1.2.3 version
+
+$ npx devvit view --json
 ```
 
 ### devvit whoami

--- a/versioned_sidebars/version-0.13-sidebars.json
+++ b/versioned_sidebars/version-0.13-sidebars.json
@@ -196,7 +196,6 @@
         "capabilities/client/navigation",
         "capabilities/client/toasts",
         "capabilities/client/menu-actions",
-        "capabilities/server/launch_screen_and_entry_points/view_modes_entry_points",
         {
           "type": "category",
           "label": "Launch Screen",


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #159

## 💸 TL;DR

This PR synchronizes Devvit’s configuration, CLI, launch-screen, and Redis documentation with the current implementation. It corrects invalid or outdated examples, documents additional supported configuration fields, and applies equivalent updates to both the current and versioned `0.13` documentation. It also centralizes the latest published documentation version through `versions.json`.

## 📜 Details

Design Doc: Not applicable

Jira: Not applicable

This documentation-only PR:

* Corrects the documented server build path, app-name limit, and default custom-post height.
* Expands the `devvit.json` reference to cover additional schema-supported settings, permissions, triggers, assets, payments, and server options.
* Updates CLI documentation for `init`, `publish`, `logs`, `playtest`, `upload`, and `view`.
* Removes references to the nonexistent `devvit build` command and `--here` option.
* Replaces deprecated launch-screen mode-listener examples with the current focus-based approach.
* Corrects stale Redis links and repairs a malformed transaction example.
* Removes a duplicated sidebar entry and fixes minor changelog errors.
* Derives `LATEST_DEVVIT_VERSION` from the first entry in `versions.json` rather than duplicating the version in `docusaurus.config.ts`.
* Mirrors applicable changes in both `docs/` and `versioned_docs/version-0.13/`.

This PR does not change Devvit runtime behavior, generated API references, Blob Storage permission behavior, or Reddit subscription identity APIs.

## 🧪 Testing Steps / Validation

The following checks were completed against the current repository snapshot:

1. Applied the patch successfully with:

   ```bash
   git apply --check devvit-docs-patch-1-docs-sync.patch
   ```

2. Checked the resulting diff for whitespace errors:

   ```bash
   git diff --check
   ```

3. Parsed all JSON code blocks changed in the configuration guides.

4. Verified that relative documentation links in the changed files resolve.

5. Checked that Markdown code fences remain balanced.

6. Checked the changed documentation for unexpected control characters.

7. Confirmed that equivalent updates were made to the current and versioned `0.13` documentation where applicable.

A complete local Docusaurus build was not run because installed dependencies were not included in the supplied repository snapshot. Repository CI should run the full documentation build.

> **CI note:** The `Build Documentation` workflow is currently marked `action_required` because this pull request originates from a fork. A repository maintainer must approve the workflow before the CI jobs can run. No CI failures have been reported at this stage.

## ✅ Checks

* [ ] CI tests (if present) are passing
* [x] Adheres to code style for repo
* [x] Contributor License Agreement (CLA) completed if not a Reddit employee