### PR TITLE
docs: add pre-build tests, comment design, sharing drivers, and a polish checklist

### DIFF
--- a/docs/guides/best-practices/community_games.md
+++ b/docs/guides/best-practices/community_games.md
@@ -4,6 +4,19 @@ Community games are multiplayer experiences that tap into Reddit’s unique soci
 
 This guide provides practical tips to help you create engaging community games that thrive in Reddit's ecosystem. Read on to learn about the kinds of mechanics that help drive long-term engagement and unlock a shot at [featuring placements](../launch/feature-guide.mdx) for your app.
 
+## Two tests before you build
+
+Before you write code, check your concept against two questions. If either answer is no, change the concept rather than trying to patch it later with retention features.
+
+**Does it get better as more people play?** A good Reddit game is playable with two people and much more fun with a thousand. The [core design principles](#core-design-principles) below call this scaling from one to many, and the steepness of that curve matters as much as its direction. If a thousand players only add rows to a leaderboard, the concept is not there yet.
+
+**Can it be played 100 days in a row?** Streaks, leagues, and notifications reinforce a loop that already works. They cannot rescue one that becomes a chore by day ten.
+
+Two concepts pass a quick review and still fail both tests:
+
+- **Parallel play.** If a session leaves no trace in shared state, players are playing next to the community instead of with it. Make each session change something everyone can see: a play count, a running total, a shifted average, a ghost of a previous run, or a mark left on a shared board.
+- **Straight ports.** Relaunching an existing single-player game on Reddit rarely works on its own. The community needs something to do, not just something to watch.
+
 ## Player retention
 
 Retention is the art of giving players a reason to come back tomorrow. Most successful games create simple, repeatable patterns that become part of the player’s daily routine.
@@ -69,6 +82,60 @@ Use rewards to reinforce meaningful participation. Allow players to accumulate *
 Reddit prioritizes sustained engagement over short spikes.
 
 Games that consistently bring players back through progression, competition, and repeatable loops build strong retention curves. That ongoing engagement demonstrates lasting community value, which is a key factor in featuring decisions.
+
+## Design for comments
+
+The comment thread is where a Reddit game becomes a community, and comments are the clearest signal that players are talking to each other rather than only to your app. Featuring decisions weigh [community engagement](../launch/feature-guide.mdx#featuring-considerations) directly.
+
+### Build the conditions, then follow the conversation
+
+You cannot decide in advance how a community will talk about your game. Players routinely find a use you did not design for, fixate on a detail you thought was incidental, or invent a recurring joke that becomes the reason people come back. What you can control is whether commenting is worth doing at all.
+
+These conditions reliably invite comment:
+
+- **A shareable outcome.** A score, a run, or a result someone wants to show off or complain about.
+- **A genuine ambiguity.** Something arguable, where two players can reasonably disagree.
+- **A human artifact.** Something a player made that another player can praise, mock, or build on.
+- **A visible mistake.** Failure that other players can see is more talkable than success.
+- **An incomplete picture.** Information one player has and another does not.
+
+Threads take many shapes: banter and shared misery, strategy, collective puzzle-solving, accusations and disputes, teaching newcomers, in-jokes, roleplay, team coordination, appreciation of a creation, predictions, run reports, rules-lawyering, bug reports, and rivalry callouts. You do not need to hit all of them, but you do need to leave room for at least one.
+
+**Tip**: Ship, read the thread for a week, then build toward the conversation you actually got. Adapting to an emergent behavior is usually cheaper and more effective than engineering a predicted one.
+
+### Wire the app and the thread together
+
+- **Show comments inside the app, in context.** Put them on the level they refer to, next to the creation they discuss, or attached to the specific board state. Read them with the [Reddit API](../../capabilities/server/reddit-api.mdx).
+- **Let players comment without leaving the game.** [User actions](../../capabilities/server/userActions.mdx) let your app submit a comment on the player's behalf from inside the post. Every extra step between the impulse and the comment costs you comments. Note that user actions require an explicit, manual opt-in for each action and cannot gate gameplay, so read the requirements before you build.
+
+### Credit the people who make your content
+
+If players create the content your game runs on, attribution is not optional: the [Devvit Rules](../../devvit_rules.md#keep-user-and-app-content-safe) require user-entered text and imagery to be published with reportable, actionable attribution.
+
+Recognition goes beyond the rule, and it is what keeps contributors supplying more:
+
+- Name the creator in-app when their content is played.
+- Mention them in comments when a creation does something notable.
+- Show their avatar so the contribution has a face attached.
+
+## Design for sharing
+
+Word of mouth is what turns a featuring slot into sustained growth. Choose two or three sharing drivers deliberately and build a real mechanic for each. Two that work beat twelve that were arrived at by accident.
+
+| Driver              | Mechanic                                                                                                                         |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Awe**             | Showcase the best community creations.                                                                                           |
+| **Danger**          | A shared threat, a countdown, or a community-wide loss condition.                                                                |
+| **Disagreement**    | Contested results and disputed rulings. Effective, but it can turn a thread hostile, so pair it with clear rules and moderation. |
+| **Gossip**          | Persistent identities, and a record of who helped and who betrayed.                                                              |
+| **Secrets**         | Hidden information, private roles, spoiler-tagged solutions.                                                                     |
+| **Surprise**        | Reveal the distribution after a vote, for example "only 4% guessed this".                                                        |
+| **Identity**        | Team choice, flair, cosmetics, a recognizable style of play.                                                                     |
+| **Humor**           | Drawing, naming, captioning, anything where the output can be funny.                                                             |
+| **Social currency** | Rare achievements and scores that make the sharer look good.                                                                     |
+| **Practical value** | Strategy and tips that help the next player.                                                                                     |
+| **Stories**         | Runs that produce a "you won't believe what happened" arc.                                                                       |
+| **Gifts**           | Favor mechanics, gifting, rescuing another player.                                                                               |
 
 ## Core design principles
 

--- a/docs/guides/launch/feature-guide.mdx
+++ b/docs/guides/launch/feature-guide.mdx
@@ -72,7 +72,7 @@ In order to promote a game, we need to ensure the experience for redditors meets
 - **A compelling first screen.** Your game must have a custom first screen.
 - **Cross platform support.** Your game's viewport must be accessible and clean on both mobile and desktop platforms.
 - **Self-explanatory design.** Anyone should be able to click into your post and have the context needed to learn, play, or participate.
-- **Responsive design.** All screens should be visible within fullscreen, mobile, and desktop. Avoid unnecessary scrolls. Scrolling within inline webviews is prohibited.
+- **Responsive design.** All screens should be visible within fullscreen, mobile, and desktop. Avoid unnecessary scrolls. Scrolling within inline webviews is prohibited. When content does not fit, paginate it or collapse it behind a toggle instead of adding a scroll container.
 
 ---
 
@@ -86,6 +86,21 @@ Our goal is to feature games that feel great to play and reflect Reddit's creati
 - **Innovation.** Fresh mechanics or concepts that make Reddit play unique.
 - **Performance and retention.** Stable technical performance and meaningful player return rates.
 - **Iteration.** Regular updates and responsiveness to player feedback.
+
+---
+
+## Design and polish checklist
+
+The requirements above are the floor. The items below are what separates a game that clears review from one that holds a top featuring slot.
+
+- **Make it recognizable.** A player scrolling the feed should identify your game at a glance. A distinct visual identity is what converts a scroll into a stop, and it is a different goal from simply looking clean.
+- **Animate the launch screen, tastefully.** [Launch screens are HTML](../../capabilities/server/launch_screen_and_entry_points/launch_overview.mdx), so motion is fully under your control. Keep it subtle and looping rather than a flashing attention grab.
+- **Stay visually consistent.** Treat UI, illustration, imagery, icons, and type as one product. Mismatched asset styles are the fastest way to look assembled rather than designed.
+- **Do not use emoji as UI.** Emoji in automated post text is usually fine. Emoji standing in for icons, buttons, or state indicators is not.
+- **Avoid generic AI-generated styling.** Purple-to-blue gradients, stock hero imagery, and default-looking illustration read as low effort, and a Reddit audience says so quickly. If you generate assets, art-direct them into a style of your own.
+- **Handle overflow without scrolling.** Scrolling inside inline webviews is prohibited and is worth avoiding in expanded mode too. Paginate, or collapse secondary content behind a toggle.
+- **Check that you are not capturing the scroll gesture.** Drag-and-drop interactions are the usual cause of scrolljacking in inline posts. Confirm a user can flick past your post without your game swallowing the gesture.
+- **Validate user-generated content at submission.** If players create content for other players, add a validation layer at submission time and back it with AutoMod rules in your subreddit. Devvit exposes `onAutomoderatorFilterPost` and `onAutomoderatorFilterComment` [triggers](../../capabilities/server/triggers.mdx) so your app can react when AutoMod catches something. Without this, your content supply becomes a liability the moment the game gets traction.
 
 ---
 

--- a/versioned_docs/version-0.13/guides/best-practices/community_games.md
+++ b/versioned_docs/version-0.13/guides/best-practices/community_games.md
@@ -4,6 +4,19 @@ Community games are multiplayer experiences that tap into Reddit’s unique soci
 
 This guide provides practical tips to help you create engaging community games that thrive in Reddit's ecosystem. Read on to learn about the kinds of mechanics that help drive long-term engagement and unlock a shot at [featuring placements](../launch/feature-guide.mdx) for your app.
 
+## Two tests before you build
+
+Before you write code, check your concept against two questions. If either answer is no, change the concept rather than trying to patch it later with retention features.
+
+**Does it get better as more people play?** A good Reddit game is playable with two people and much more fun with a thousand. The [core design principles](#core-design-principles) below call this scaling from one to many, and the steepness of that curve matters as much as its direction. If a thousand players only add rows to a leaderboard, the concept is not there yet.
+
+**Can it be played 100 days in a row?** Streaks, leagues, and notifications reinforce a loop that already works. They cannot rescue one that becomes a chore by day ten.
+
+Two concepts pass a quick review and still fail both tests:
+
+- **Parallel play.** If a session leaves no trace in shared state, players are playing next to the community instead of with it. Make each session change something everyone can see: a play count, a running total, a shifted average, a ghost of a previous run, or a mark left on a shared board.
+- **Straight ports.** Relaunching an existing single-player game on Reddit rarely works on its own. The community needs something to do, not just something to watch.
+
 ## Player retention
 
 Retention is the art of giving players a reason to come back tomorrow. Most successful games create simple, repeatable patterns that become part of the player’s daily routine.
@@ -69,6 +82,60 @@ Use rewards to reinforce meaningful participation. Allow players to accumulate *
 Reddit prioritizes sustained engagement over short spikes.
 
 Games that consistently bring players back through progression, competition, and repeatable loops build strong retention curves. That ongoing engagement demonstrates lasting community value, which is a key factor in featuring decisions.
+
+## Design for comments
+
+The comment thread is where a Reddit game becomes a community, and comments are the clearest signal that players are talking to each other rather than only to your app. Featuring decisions weigh [community engagement](../launch/feature-guide.mdx#featuring-considerations) directly.
+
+### Build the conditions, then follow the conversation
+
+You cannot decide in advance how a community will talk about your game. Players routinely find a use you did not design for, fixate on a detail you thought was incidental, or invent a recurring joke that becomes the reason people come back. What you can control is whether commenting is worth doing at all.
+
+These conditions reliably invite comment:
+
+- **A shareable outcome.** A score, a run, or a result someone wants to show off or complain about.
+- **A genuine ambiguity.** Something arguable, where two players can reasonably disagree.
+- **A human artifact.** Something a player made that another player can praise, mock, or build on.
+- **A visible mistake.** Failure that other players can see is more talkable than success.
+- **An incomplete picture.** Information one player has and another does not.
+
+Threads take many shapes: banter and shared misery, strategy, collective puzzle-solving, accusations and disputes, teaching newcomers, in-jokes, roleplay, team coordination, appreciation of a creation, predictions, run reports, rules-lawyering, bug reports, and rivalry callouts. You do not need to hit all of them, but you do need to leave room for at least one.
+
+**Tip**: Ship, read the thread for a week, then build toward the conversation you actually got. Adapting to an emergent behavior is usually cheaper and more effective than engineering a predicted one.
+
+### Wire the app and the thread together
+
+- **Show comments inside the app, in context.** Put them on the level they refer to, next to the creation they discuss, or attached to the specific board state. Read them with the [Reddit API](../../capabilities/server/reddit-api.mdx).
+- **Let players comment without leaving the game.** [User actions](../../capabilities/server/userActions.mdx) let your app submit a comment on the player's behalf from inside the post. Every extra step between the impulse and the comment costs you comments. Note that user actions require an explicit, manual opt-in for each action and cannot gate gameplay, so read the requirements before you build.
+
+### Credit the people who make your content
+
+If players create the content your game runs on, attribution is not optional: the [Devvit Rules](../../devvit_rules.md#keep-user-and-app-content-safe) require user-entered text and imagery to be published with reportable, actionable attribution.
+
+Recognition goes beyond the rule, and it is what keeps contributors supplying more:
+
+- Name the creator in-app when their content is played.
+- Mention them in comments when a creation does something notable.
+- Show their avatar so the contribution has a face attached.
+
+## Design for sharing
+
+Word of mouth is what turns a featuring slot into sustained growth. Choose two or three sharing drivers deliberately and build a real mechanic for each. Two that work beat twelve that were arrived at by accident.
+
+| Driver              | Mechanic                                                                                                                         |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Awe**             | Showcase the best community creations.                                                                                           |
+| **Danger**          | A shared threat, a countdown, or a community-wide loss condition.                                                                |
+| **Disagreement**    | Contested results and disputed rulings. Effective, but it can turn a thread hostile, so pair it with clear rules and moderation. |
+| **Gossip**          | Persistent identities, and a record of who helped and who betrayed.                                                              |
+| **Secrets**         | Hidden information, private roles, spoiler-tagged solutions.                                                                     |
+| **Surprise**        | Reveal the distribution after a vote, for example "only 4% guessed this".                                                        |
+| **Identity**        | Team choice, flair, cosmetics, a recognizable style of play.                                                                     |
+| **Humor**           | Drawing, naming, captioning, anything where the output can be funny.                                                             |
+| **Social currency** | Rare achievements and scores that make the sharer look good.                                                                     |
+| **Practical value** | Strategy and tips that help the next player.                                                                                     |
+| **Stories**         | Runs that produce a "you won't believe what happened" arc.                                                                       |
+| **Gifts**           | Favor mechanics, gifting, rescuing another player.                                                                               |
 
 ## Core design principles
 

--- a/versioned_docs/version-0.13/guides/launch/feature-guide.mdx
+++ b/versioned_docs/version-0.13/guides/launch/feature-guide.mdx
@@ -72,7 +72,7 @@ In order to promote a game, we need to ensure the experience for redditors meets
 - **A compelling first screen.** Your game must have a custom first screen.
 - **Cross platform support.** Your game's viewport must be accessible and clean on both mobile and desktop platforms.
 - **Self-explanatory design.** Anyone should be able to click into your post and have the context needed to learn, play, or participate.
-- **Responsive design.** All screens should be visible within fullscreen, mobile, and desktop. Avoid unnecessary scrolls. Scrolling within inline webviews is prohibited.
+- **Responsive design.** All screens should be visible within fullscreen, mobile, and desktop. Avoid unnecessary scrolls. Scrolling within inline webviews is prohibited. When content does not fit, paginate it or collapse it behind a toggle instead of adding a scroll container.
 
 ---
 
@@ -86,6 +86,21 @@ Our goal is to feature games that feel great to play and reflect Reddit's creati
 - **Innovation.** Fresh mechanics or concepts that make Reddit play unique.
 - **Performance and retention.** Stable technical performance and meaningful player return rates.
 - **Iteration.** Regular updates and responsiveness to player feedback.
+
+---
+
+## Design and polish checklist
+
+The requirements above are the floor. The items below are what separates a game that clears review from one that holds a top featuring slot.
+
+- **Make it recognizable.** A player scrolling the feed should identify your game at a glance. A distinct visual identity is what converts a scroll into a stop, and it is a different goal from simply looking clean.
+- **Animate the launch screen, tastefully.** [Launch screens are HTML](../../capabilities/server/launch_screen_and_entry_points/launch_overview.mdx), so motion is fully under your control. Keep it subtle and looping rather than a flashing attention grab.
+- **Stay visually consistent.** Treat UI, illustration, imagery, icons, and type as one product. Mismatched asset styles are the fastest way to look assembled rather than designed.
+- **Do not use emoji as UI.** Emoji in automated post text is usually fine. Emoji standing in for icons, buttons, or state indicators is not.
+- **Avoid generic AI-generated styling.** Purple-to-blue gradients, stock hero imagery, and default-looking illustration read as low effort, and a Reddit audience says so quickly. If you generate assets, art-direct them into a style of your own.
+- **Handle overflow without scrolling.** Scrolling inside inline webviews is prohibited and is worth avoiding in expanded mode too. Paginate, or collapse secondary content behind a toggle.
+- **Check that you are not capturing the scroll gesture.** Drag-and-drop interactions are the usual cause of scrolljacking in inline posts. Confirm a user can flick past your post without your game swallowing the gesture.
+- **Validate user-generated content at submission.** If players create content for other players, add a validation layer at submission time and back it with AutoMod rules in your subreddit. Devvit exposes `onAutomoderatorFilterPost` and `onAutomoderatorFilterComment` [triggers](../../capabilities/server/triggers.mdx) so your app can react when AutoMod catches something. Without this, your content supply becomes a liability the moment the game gets traction.
 
 ---
 


### PR DESCRIPTION
## What this adds

Practical guidance drawn from building and shipping Devvit games. Everything lands in existing pages; no new files, no sidebar changes.

### `guides/best-practices/community_games.md`

**Two tests before you build** (new section, above Player retention)
Two go/no-go questions to run a concept through before writing code: does it get better as more people play, and can it be played 100 days in a row. The existing "scale from one to many" principle says the right thing, and this sharpens it: the steepness of the curve is the point, not just its direction. It also names the two shapes that pass a surface review and still fail, because both are common in submissions:

- **Parallel play**, where a session leaves no trace in shared state, so the player is playing next to the community rather than with it.
- **Straight ports** of existing single-player games, where the community has something to watch but nothing to do.

**Design for comments** (new section)
The docs list "community engagement" as a featuring consideration but do not say how to earn it. This covers the conditions that reliably invite comments (a shareable outcome, a genuine ambiguity, a human artifact, a visible mistake, an incomplete picture), wiring the app and the thread together in both directions, and crediting creators. The wiring points link to the Reddit API and to user actions, and the attribution point links to the existing requirement in the Devvit Rules rather than restating it.

It deliberately does not promise that you can predict the conversation. The recommendation is to ship, read the thread for a week, and build toward the conversation you actually got.

**Design for sharing** (new section)
A table of sharing drivers and the mechanic that produces each one, so developers can pick two or three on purpose instead of ending up with twelve by accident.

### `guides/launch/feature-guide.mdx`

**Design and polish checklist** (new section, after Featuring considerations)
"Design and polish" is currently listed as a consideration with no definition. This makes it concrete: be recognizable in the feed, animate the launch screen tastefully, keep asset styles consistent, do not use emoji as UI elements, avoid generic AI-generated styling, do not capture the scroll gesture with drag-and-drop, and validate user-generated content at submission.

**Responsive design requirement**
The requirement says scrolling within inline webviews is prohibited but does not say what to do instead. Adds pagination and toggles as the alternative.

## Notes for reviewers

- Mirrored into `versioned_docs/version-0.13` per the repo README.
- Voice and formatting follow the surrounding pages: second person, bold lead-ins, `**Tip**:` callouts, tables for the driver list.
- All added internal links point at existing files in both `docs/` and `versioned_docs/version-0.13/`.
- Happy to split this into two PRs, cut any section, or soften anything that reads as too prescriptive for official docs.

I have completed the CLA.