### PR TITLE
Update Redis storage limits to be per install

### DIFF
--- a/docs/capabilities/server/redis.mdx
+++ b/docs/capabilities/server/redis.mdx
@@ -64,7 +64,7 @@ For command-specific behavior and limits, see the [supported Redis commands](#su
 
 ## Storage values
 
-Redis is best for small, frequently accessed app states. Each Redis installation has a 5 MB request size limit, and each app has an overall Redis storage limit of 5GB. On occasion, apps will run into storage limits. Our team will reach out to you if this occurs and work with you to optimize your app.
+Redis is best for small, frequently accessed app states. Each Redis installation has a 5 MB request size limit and a 5 GB storage limit. On occasion, apps will run into storage limits. Our team will reach out to you if this occurs and work with you to optimize your app.
 
 If your app stores large JSON objects, long text values, or historical records that still belong in Redis, use`redisCompressed`. 
 
@@ -178,7 +178,7 @@ Design around these limits early so your app stays responsive as more people use
 | :---- | :---- | :---- |
 | Command throughput | 40,000 commands per second per installation | Avoid one Redis call per item in hot loops. Use batch commands such as `mGet`, `mSet`, and `hash` writes where they fit. |
 | Pipelining | Not supported | Reduce round trips by grouping related fields under hashes or compact JSON values. |
-| Overall app storage usage | 5 GB across all installations | Keep long-lived data compact, expire temporary keys, and archive large historical data outside Redis when needed. |
+| Storage usage | 5 GB per installation | Keep long-lived data compact, expire temporary keys, and archive large historical data outside Redis when needed. |
 | Request size | 5 MB | Store large datasets as multiple records and process them in batches. |
 | Transactions | 20 concurrent transaction blocks; 5-second execution timeout | Keep transaction logic small and release transactions with `exec`, `discard`, or `unwatch`. |
 

--- a/docs/guides/faq.mdx
+++ b/docs/guides/faq.mdx
@@ -434,7 +434,7 @@ You can also edit the display name, about description, and mature flag (18+) fie
 
 There's no single limits page today, but these are the most commonly referenced numbers in the docs:
 
-- [Redis](../capabilities/server/redis.mdx): 5 GB overall app storage usage, 5 MB max request size, and 40,000 max commands per second.
+- [Redis](../capabilities/server/redis.mdx): 5 GB max storage per installation, 5 MB max request size, and 40,000 max commands per second.
 - [Devvit Web](../capabilities/devvit-web/devvit_web_overview.mdx): 30 second max request time, 4 MB max payload size, and 10 MB max response size.
 - [Post data](../capabilities/server/post-data.mdx): 2 KB per post.
 - [Settings and secrets](../capabilities/server/settings-and-secrets.mdx): 2 KB per setting value.

--- a/versioned_docs/version-0.12/capabilities/server/redis.mdx
+++ b/versioned_docs/version-0.12/capabilities/server/redis.mdx
@@ -18,14 +18,13 @@ Each installation of an app is uniquely name-spaced, which means Redis data is s
 
 - Max commands per second: 40000
 - Max request size: 5 MB
-- Max storage: 500 MB
-- Overall app storage usage: 5 GB
+- Max storage: 5 GB
 - [Pipelining](https://redis.io/docs/latest/develop/using-commands/pipelining/) is not supported
 - [Sets](https://redis.io/docs/latest/commands/set/) - only sorted sets are supported
 - No support for listing keys
 - No support for lua scripts to execute custom logic on redis server
 
-All limits are applied at a per-installation granularity except for the overall app storage usage limit, which applies across all installations.
+All limits are applied per installation.
 
 ## Examples
 

--- a/versioned_docs/version-0.12/guides/faq.mdx
+++ b/versioned_docs/version-0.12/guides/faq.mdx
@@ -396,7 +396,7 @@ You can also edit the display name, about description, and mature flag (18+) fie
 
 There's no single limits page today, but these are the most commonly referenced numbers in the docs:
 
-- [Redis](../capabilities/server/redis.mdx): 500 MB max storage per installation, 5 GB overall app storage usage, 5 MB max request size, and 40,000 max commands per second.
+- [Redis](../capabilities/server/redis.mdx): 5 GB max storage per installation, 5 MB max request size, and 40,000 max commands per second.
 - [Devvit Web](../capabilities/devvit-web/devvit_web_overview.mdx): 30 second max request time, 4 MB max payload size, and 10 MB max response size.
 - [Post data](../capabilities/server/post-data.mdx): 2 KB per post.
 - [Settings and secrets](../capabilities/server/settings-and-secrets.mdx): 2 KB per setting value.

--- a/versioned_docs/version-0.13/capabilities/server/redis.mdx
+++ b/versioned_docs/version-0.13/capabilities/server/redis.mdx
@@ -64,7 +64,7 @@ For command-specific behavior and limits, see the [supported Redis commands](#su
 
 ## Storage values
 
-Redis is best for small, frequently accessed app states. Each Redis installation has a 5 MB request size limit, and each app has an overall Redis storage limit of 5GB. On occasion, apps will run into storage limits. Our team will reach out to you if this occurs and work with you to optimize your app.
+Redis is best for small, frequently accessed app states. Each Redis installation has a 5 MB request size limit and a 5 GB storage limit. On occasion, apps will run into storage limits. Our team will reach out to you if this occurs and work with you to optimize your app.
 
 If your app stores large JSON objects, long text values, or historical records that still belong in Redis, use`redisCompressed`. 
 
@@ -178,7 +178,7 @@ Design around these limits early so your app stays responsive as more people use
 | :---- | :---- | :---- |
 | Command throughput | 40,000 commands per second per installation | Avoid one Redis call per item in hot loops. Use batch commands such as `mGet`, `mSet`, and `hash` writes where they fit. |
 | Pipelining | Not supported | Reduce round trips by grouping related fields under hashes or compact JSON values. |
-| Overall app storage usage | 5 GB across all installations | Keep long-lived data compact, expire temporary keys, and archive large historical data outside Redis when needed. |
+| Storage usage | 5 GB per installation | Keep long-lived data compact, expire temporary keys, and archive large historical data outside Redis when needed. |
 | Request size | 5 MB | Store large datasets as multiple records and process them in batches. |
 | Transactions | 20 concurrent transaction blocks; 5-second execution timeout | Keep transaction logic small and release transactions with `exec`, `discard`, or `unwatch`. |
 

--- a/versioned_docs/version-0.13/guides/faq.mdx
+++ b/versioned_docs/version-0.13/guides/faq.mdx
@@ -434,7 +434,7 @@ You can also edit the display name, about description, and mature flag (18+) fie
 
 There's no single limits page today, but these are the most commonly referenced numbers in the docs:
 
-- [Redis](../capabilities/server/redis.mdx): 5 GB overall app storage usage, 5 MB max request size, and 40,000 max commands per second.
+- [Redis](../capabilities/server/redis.mdx): 5 GB max storage per installation, 5 MB max request size, and 40,000 max commands per second.
 - [Devvit Web](../capabilities/devvit-web/devvit_web_overview.mdx): 30 second max request time, 4 MB max payload size, and 10 MB max response size.
 - [Post data](../capabilities/server/post-data.mdx): 2 KB per post.
 - [Settings and secrets](../capabilities/server/settings-and-secrets.mdx): 2 KB per setting value.

--- a/versioned_docs/version-0.14/capabilities/server/redis.mdx
+++ b/versioned_docs/version-0.14/capabilities/server/redis.mdx
@@ -64,7 +64,7 @@ For command-specific behavior and limits, see the [supported Redis commands](#su
 
 ## Storage values
 
-Redis is best for small, frequently accessed app states. Each Redis installation has a 5 MB request size limit, and each app has an overall Redis storage limit of 5GB. On occasion, apps will run into storage limits. Our team will reach out to you if this occurs and work with you to optimize your app.
+Redis is best for small, frequently accessed app states. Each Redis installation has a 5 MB request size limit and a 5 GB storage limit. On occasion, apps will run into storage limits. Our team will reach out to you if this occurs and work with you to optimize your app.
 
 If your app stores large JSON objects, long text values, or historical records that still belong in Redis, use`redisCompressed`. 
 
@@ -178,7 +178,7 @@ Design around these limits early so your app stays responsive as more people use
 | :---- | :---- | :---- |
 | Command throughput | 40,000 commands per second per installation | Avoid one Redis call per item in hot loops. Use batch commands such as `mGet`, `mSet`, and `hash` writes where they fit. |
 | Pipelining | Not supported | Reduce round trips by grouping related fields under hashes or compact JSON values. |
-| Overall app storage usage | 5 GB across all installations | Keep long-lived data compact, expire temporary keys, and archive large historical data outside Redis when needed. |
+| Storage usage | 5 GB per installation | Keep long-lived data compact, expire temporary keys, and archive large historical data outside Redis when needed. |
 | Request size | 5 MB | Store large datasets as multiple records and process them in batches. |
 | Transactions | 20 concurrent transaction blocks; 5-second execution timeout | Keep transaction logic small and release transactions with `exec`, `discard`, or `unwatch`. |
 

--- a/versioned_docs/version-0.14/guides/faq.mdx
+++ b/versioned_docs/version-0.14/guides/faq.mdx
@@ -434,7 +434,7 @@ You can also edit the display name, about description, and mature flag (18+) fie
 
 There's no single limits page today, but these are the most commonly referenced numbers in the docs:
 
-- [Redis](../capabilities/server/redis.mdx): 5 GB overall app storage usage, 5 MB max request size, and 40,000 max commands per second.
+- [Redis](../capabilities/server/redis.mdx): 5 GB max storage per installation, 5 MB max request size, and 40,000 max commands per second.
 - [Devvit Web](../capabilities/devvit-web/devvit_web_overview.mdx): 30 second max request time, 4 MB max payload size, and 10 MB max response size.
 - [Post data](../capabilities/server/post-data.mdx): 2 KB per post.
 - [Settings and secrets](../capabilities/server/settings-and-secrets.mdx): 2 KB per setting value.


### PR DESCRIPTION
This updates storage limits on the Redis and FAQ pages to be per install.