### PR TITLE
Add leading '#' character for 0.14 changelog header

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ To use the latest version of Devvit:
 
 **Please note**: you may see features available across Devvit packages that are not documented or noted in our changelog. These are experimental features that are not stable and are subject to change, or removal, from the platform. Please use caution when testing or implementing experimental features.
 
-# Release 0.14.0: Node.js v24, Wiki Integration, Devvit Skills (Experimental)
+## Release 0.14.0: Node.js v24, Wiki Integration, Devvit Skills (Experimental)
 **Release Date: August 10, 2026**
 
 **Node.js Upgrade**
@@ -43,6 +43,8 @@ The first available skill, `devvit-docs`, helps agents answer Devvit questions u
 **Devvit Test Redis Changes**
 
 We’ve migrated to a JS only implementation of Redis inside of [Devvit test](https://developers.reddit.com/docs/guides/tools/devvit_test). This should make it easier to install and work with. While not a breaking change, it's possible the new Redis mock behaves differently compared to the previous version. If you run into any issues, please [let us know on Github](https://github.com/reddit/devvit)!
+
+
 ## Release 0.13.11: Behind-the-Scenes Improvements
 **Release Date: August 3, 2026***
 

--- a/versioned_docs/version-0.14/changelog.md
+++ b/versioned_docs/version-0.14/changelog.md
@@ -9,7 +9,7 @@ To use the latest version of Devvit:
 
 **Please note**: you may see features available across Devvit packages that are not documented or noted in our changelog. These are experimental features that are not stable and are subject to change, or removal, from the platform. Please use caution when testing or implementing experimental features.
 
-# Release 0.14.0: Node.js v24, Wiki Integration, Devvit Skills (Experimental)
+## Release 0.14.0: Node.js v24, Wiki Integration, Devvit Skills (Experimental)
 **Release Date: August 10, 2026**
 
 **Node.js Upgrade**
@@ -43,6 +43,8 @@ The first available skill, `devvit-docs`, helps agents answer Devvit questions u
 **Devvit Test Redis Changes**
 
 We’ve migrated to a JS only implementation of Redis inside of [Devvit test](https://developers.reddit.com/docs/guides/tools/devvit_test). This should make it easier to install and work with. While not a breaking change, it's possible the new Redis mock behaves differently compared to the previous version. If you run into any issues, please [let us know on Github](https://github.com/reddit/devvit)!
+
+
 ## Release 0.13.11: Behind-the-Scenes Improvements
 **Release Date: August 3, 2026***
 


### PR DESCRIPTION
## 💸 TL;DR
I meant to add an extra `#` header in the changelog notes for `0.14.0` so we can link to the header. This PR adds that.

## 📜 Details
Self-explanatory.

## 🧪 Testing Steps / Validation
Ran `yarn start`, verified the UI looks as expected:

<img width="948" height="347" alt="Screenshot 2026-08-10 at 2 24 56 PM" src="https://github.com/user-attachments/assets/7ce11cf9-1ba9-47ea-b791-67cc68660f26" />

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee