### PR TITLE
menu-actions forUserType update

### DIFF
--- a/docs/capabilities/client/menu-actions.mdx
+++ b/docs/capabilities/client/menu-actions.mdx
@@ -75,11 +75,11 @@ app.post<string, never, UiResponse, MenuItemRequest>(
 
 You can decide where the menu action shows up by specifying the location property.
 
-| Property               | Values                         | Description                                                                     |
-| ---------------------- | ------------------------------ | ------------------------------------------------------------------------------- |
-| location (required)    | `comment`, `post`, `subreddit` | Determines where the menu action appears.                    |
-| postFilter (optional)  | `currentApp`                   | Shows the action created by your app. The default is no filtering.              |
-| forUserType (optional) | `moderator`                    | Specifies the user types that can see the menu action. The default is everyone. |
+| Property               | Values                         | Description                                                                               |
+| ---------------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| location (required)    | `comment`, `post`, `subreddit` | Determines where the menu action appears.                                                 |
+| postFilter (optional)  | `currentApp`                   | Shows the action created by your app. The default is no filtering.                        |
+| forUserType (optional) | `moderator`, `user`            | Specifies who can see the menu action. The default is `moderator`; use `user` for all users. |
 
 :::note
 For moderator permission security, when opening a form from a menu action with `forUserType: moderator`, the user initiating the action must complete all actions within 10 minutes.

--- a/versioned_docs/version-0.14/capabilities/client/menu-actions.mdx
+++ b/versioned_docs/version-0.14/capabilities/client/menu-actions.mdx
@@ -75,11 +75,11 @@ app.post<string, never, UiResponse, MenuItemRequest>(
 
 You can decide where the menu action shows up by specifying the location property.
 
-| Property               | Values                         | Description                                                                     |
-| ---------------------- | ------------------------------ | ------------------------------------------------------------------------------- |
-| location (required)    | `comment`, `post`, `subreddit` | Determines where the menu action appears.                    |
-| postFilter (optional)  | `currentApp`                   | Shows the action created by your app. The default is no filtering.              |
-| forUserType (optional) | `moderator`                    | Specifies the user types that can see the menu action. The default is everyone. |
+| Property               | Values                         | Description                                                                               |
+| ---------------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| location (required)    | `comment`, `post`, `subreddit` | Determines where the menu action appears.                                                 |
+| postFilter (optional)  | `currentApp`                   | Shows the action created by your app. The default is no filtering.                        |
+| forUserType (optional) | `moderator`, `user`            | Specifies who can see the menu action. The default is `moderator`; use `user` for all users. |
 
 :::note
 For moderator permission security, when opening a form from a menu action with `forUserType: moderator`, the user initiating the action must complete all actions within 10 minutes.


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #77 

## 💸 TL;DR
The current devvit.json schema says forUserType defaults to moderator, not everyone. The menu-actions table now lists both valid values, moderator and user, and clarifies that user is required to show a menu action to all users.